### PR TITLE
Add runtime v0.25.0 metrics and autoscaling support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: trussiumhq/trussium
-          ref: v0.24.0
+          ref: v0.25.0
           path: runtime
 
       - name: Install Helm

--- a/README.md
+++ b/README.md
@@ -12,20 +12,25 @@ future `trussium-operator`.
 
 ## What the chart installs
 
-- A hardened, replicated Trussium Deployment.
+- A hardened, autoscaled Trussium Deployment.
 - A ClusterIP Service on port 9000 by default.
 - A ServiceAccount without API-token automounting.
 - A ConfigMap containing non-secret runtime settings.
 - An optional reference to an existing provider Secret.
 - A PodDisruptionBudget and topology-spread constraints.
+- An `autoscaling/v2` HorizontalPodAutoscaler with conservative production
+  behavior.
 
 No Namespace, provider credentials, registry credentials, Ingress,
-HorizontalPodAutoscaler, or monitoring custom resources are created.
+Prometheus, Prometheus Adapter, monitoring custom resources, or operator
+resources are created.
 
 ## Prerequisites
 
 - Kubernetes 1.25 or newer.
 - Helm 3.12 or newer.
+- A working Kubernetes Metrics API when default autoscaling is enabled,
+  commonly provided by Metrics Server.
 - Access to `ghcr.io/trussiumhq/trussium`.
 
 The Trussium runtime package currently requires authenticated GHCR access.
@@ -58,6 +63,17 @@ helm install trussium \
 
 The chart defaults to the compatible runtime release in `Chart.yaml`'s
 `appVersion`. Chart and runtime versions are intentionally independent.
+
+## Compatibility
+
+| Chart release | Default runtime | Kubernetes |
+| --- | --- | --- |
+| `0.2.x` | `0.25.x` | `>=1.25` |
+| `0.1.x` | `0.24.x` | `>=1.25` |
+
+Compatibility means the default runtime image and the chart deployment
+contract are validated together. Overriding `image.tag` is supported, but the
+operator owns compatibility validation for that combination.
 
 For a local checkout:
 
@@ -111,7 +127,10 @@ helm show values oci://ghcr.io/trussiumhq/charts/trussium \
 Common production overrides:
 
 ```yaml
-replicaCount: 3
+autoscaling:
+  minReplicas: 3
+  maxReplicas: 20
+  targetCPUUtilizationPercentage: 65
 
 imagePullSecrets:
   - name: organization-ghcr-credentials
@@ -128,6 +147,22 @@ timeouts:
   providerRequestSeconds: 90
   streamIdleSeconds: 45
 ```
+
+The chart enables runtime metrics at `/metrics` and CPU-based horizontal
+autoscaling by default. The HPA uses Kubernetes resource metrics; it does not
+require Prometheus. To use a fixed replica count instead:
+
+```yaml
+autoscaling:
+  enabled: false
+replicaCount: 3
+```
+
+Do not manually scale the Deployment while the HPA is enabled. Tune the HPA
+bounds and target instead. See the
+[runtime metrics guide](https://github.com/trussiumhq/trussium/blob/main/docs/METRICS.md)
+for the bounded Prometheus-compatible metric contract and optional custom
+metrics extension point.
 
 The complete value reference is in the
 [chart README](charts/trussium/README.md). `values.schema.json` rejects unknown
@@ -185,9 +220,10 @@ scripts/helm-validate.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.24.0` from a neighboring
-checkout and validates install, readiness, HTTP request correlation, upgrade,
-rollback, and uninstall:
+The complete Kind lifecycle test builds runtime `v0.25.0` from a neighboring
+checkout, installs pinned Metrics Server v0.8.1, and validates install, live
+autoscaling, runtime metrics, readiness, HTTP request correlation, fixed-scale
+upgrade, autoscaling rollback, and uninstall:
 
 ```bash
 TRUSSIUM_RUNTIME_SOURCE=../trussium scripts/chart-smoke-test.sh

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.1.0
-appVersion: "0.24.0"
+appVersion: "0.25.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -8,7 +8,7 @@ default compatible runtime image.
 
 | Value | Default | Purpose |
 | --- | --- | --- |
-| `replicaCount` | `2` | Desired runtime replicas. |
+| `replicaCount` | `2` | Desired replicas when autoscaling is disabled. |
 | `revisionHistoryLimit` | `3` | Retained Deployment revisions. |
 | `image.repository` | `ghcr.io/trussiumhq/trussium` | Runtime image repository. |
 | `image.tag` | `""` | Image tag; empty uses chart `appVersion`. |
@@ -33,6 +33,12 @@ default compatible runtime image.
 | `runtime.gracefulShutdownSeconds` | `30` | Active-workload drain deadline. |
 | `timeouts.providerRequestSeconds` | `60` | Provider request deadline. |
 | `timeouts.streamIdleSeconds` | `30` | Streaming event idle deadline. |
+| `observability.metrics.enabled` | `true` | Expose runtime metrics at `/metrics`. |
+| `autoscaling.enabled` | `true` | Create the runtime HorizontalPodAutoscaler. |
+| `autoscaling.minReplicas` | `2` | Autoscaling availability floor. |
+| `autoscaling.maxReplicas` | `10` | Autoscaling replica ceiling. |
+| `autoscaling.targetCPUUtilizationPercentage` | `70` | Named-container CPU target. |
+| `autoscaling.behavior` | production defaults | Scale velocity and stabilization rules. |
 | `providerSecret.name` | `trussium-provider` | Existing provider Secret; empty disables it. |
 | `providerSecret.optional` | `true` | Allow startup when that Secret is absent. |
 | `extraConfig` | `{}` | Additional non-secret ConfigMap entries. |
@@ -53,3 +59,24 @@ default compatible runtime image.
 | `priorityClassName` | `""` | Existing PriorityClass name. |
 
 The JSON Schema in the chart is authoritative for value types and constraints.
+
+## Autoscaling and metrics
+
+Default rendering omits Deployment `spec.replicas` so the
+HorizontalPodAutoscaler owns scale. It targets the named `trussium` container,
+can grow by at most 100% or four pods per minute, and uses a five-minute
+scale-down stabilization window with a 25% or one-pod per-minute limit.
+
+The default CPU signal requires Kubernetes Metrics API, commonly supplied by
+Metrics Server. It does not require Prometheus. Disable autoscaling to restore
+fixed `replicaCount` ownership:
+
+```yaml
+autoscaling:
+  enabled: false
+replicaCount: 3
+```
+
+Runtime metrics remain independently configurable through
+`observability.metrics.enabled`. The chart does not install Prometheus,
+Prometheus Adapter, ServiceMonitor, or other monitoring resources.

--- a/charts/trussium/templates/NOTES.txt
+++ b/charts/trussium/templates/NOTES.txt
@@ -2,9 +2,17 @@ Trussium runtime {{ .Chart.AppVersion }} has been installed as release {{ .Relea
 
 Check the rollout:
   kubectl rollout status --namespace {{ .Release.Namespace }} deployment/{{ include "trussium.fullname" . }}
+{{- if .Values.autoscaling.enabled }}
+
+Check horizontal autoscaling:
+  kubectl get --namespace {{ .Release.Namespace }} horizontalpodautoscaler/{{ include "trussium.fullname" . }}
+{{- end }}
 
 Reach the runtime locally:
   kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ include "trussium.fullname" . }} 9000:{{ .Values.service.port }}
   curl http://127.0.0.1:9000/health/ready
+{{- if .Values.observability.metrics.enabled }}
+  curl http://127.0.0.1:9000/metrics
+{{- end }}
 
 This chart installs the Trussium runtime only. It does not install trussium-operator.

--- a/charts/trussium/templates/configmap.yaml
+++ b/charts/trussium/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
   TRUSSIUM_RUNTIME__GRACEFUL_SHUTDOWN_SECONDS: {{ .Values.runtime.gracefulShutdownSeconds | quote }}
   TRUSSIUM_TIMEOUTS__PROVIDER_REQUEST_SECONDS: {{ .Values.timeouts.providerRequestSeconds | quote }}
   TRUSSIUM_TIMEOUTS__STREAM_IDLE_SECONDS: {{ .Values.timeouts.streamIdleSeconds | quote }}
+  TRUSSIUM_OBSERVABILITY__METRICS_ENABLED: {{ .Values.observability.metrics.enabled | quote }}
   {{- range $key, $value := .Values.extraConfig }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/trussium/templates/deployment.yaml
+++ b/charts/trussium/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "trussium.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   strategy:
     type: {{ .Values.deploymentStrategy.type }}

--- a/charts/trussium/templates/horizontalpodautoscaler.yaml
+++ b/charts/trussium/templates/horizontalpodautoscaler.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+{{- if gt (int .Values.autoscaling.minReplicas) (int .Values.autoscaling.maxReplicas) }}
+{{- fail "autoscaling.minReplicas must be less than or equal to autoscaling.maxReplicas" }}
+{{- end }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "trussium.fullname" . }}
+  labels:
+    {{- include "trussium.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "trussium.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+  metrics:
+    - type: ContainerResource
+      containerResource:
+        name: cpu
+        container: trussium
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/trussium/values.schema.json
+++ b/charts/trussium/values.schema.json
@@ -14,6 +14,8 @@
     "service",
     "runtime",
     "timeouts",
+    "observability",
+    "autoscaling",
     "providerSecret",
     "startupProbe",
     "livenessProbe",
@@ -93,6 +95,51 @@
         "streamIdleSeconds": {"type": "integer", "minimum": 1}
       }
     },
+    "observability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metrics"],
+      "properties": {
+        "metrics": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabled"],
+          "properties": {
+            "enabled": {"type": "boolean"}
+          }
+        }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "minReplicas",
+        "maxReplicas",
+        "targetCPUUtilizationPercentage",
+        "behavior"
+      ],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "minReplicas": {"type": "integer", "minimum": 1},
+        "maxReplicas": {"type": "integer", "minimum": 1},
+        "targetCPUUtilizationPercentage": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "behavior": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["scaleUp", "scaleDown"],
+          "properties": {
+            "scaleUp": {"$ref": "#/definitions/scalingRules"},
+            "scaleDown": {"$ref": "#/definitions/scalingRules"}
+          }
+        }
+      }
+    },
     "providerSecret": {
       "type": "object",
       "additionalProperties": false,
@@ -155,6 +202,34 @@
     "priorityClassName": {"type": "string"}
   },
   "definitions": {
+    "scalingPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "value", "periodSeconds"],
+      "properties": {
+        "type": {"type": "string", "enum": ["Pods", "Percent"]},
+        "value": {"type": "integer", "minimum": 1},
+        "periodSeconds": {"type": "integer", "minimum": 1, "maximum": 1800}
+      }
+    },
+    "scalingRules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stabilizationWindowSeconds", "selectPolicy", "policies"],
+      "properties": {
+        "stabilizationWindowSeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3600
+        },
+        "selectPolicy": {"type": "string", "enum": ["Max", "Min", "Disabled"]},
+        "policies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/definitions/scalingPolicy"}
+        }
+      }
+    },
     "probe": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/trussium/values.yaml
+++ b/charts/trussium/values.yaml
@@ -49,6 +49,37 @@ timeouts:
   providerRequestSeconds: 60
   streamIdleSeconds: 30
 
+observability:
+  metrics:
+    enabled: true
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      selectPolicy: Max
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      selectPolicy: Min
+      policies:
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+
 providerSecret:
   name: trussium-provider
   optional: true

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,10 +9,10 @@ remains a separate project.
 
 ## Current focus
 
-The first production Helm chart now carries the validated Trussium v0.24.0
+The production Helm chart now carries the validated Trussium v0.25.0
 Kubernetes contract into an independently released distribution:
 
-- Hardened replicated runtime pods.
+- Hardened autoscaled runtime pods with a two-replica availability floor.
 - Configurable non-secret runtime settings and existing Secret integration.
 - Private-registry authentication, health probes, resource boundaries,
   topology spreading, zero-unavailable rolling updates, disruption protection,
@@ -21,6 +21,12 @@ Kubernetes contract into an independently released distribution:
 - A real Kind lifecycle test covering install, health, upgrade, rollback, and
   uninstall.
 - Independent Conventional Commit releases with GitHub and OCI artifacts.
+- Prometheus-compatible runtime metrics enabled by default.
+- Configurable `autoscaling/v2` HorizontalPodAutoscaler using the named
+  runtime container's CPU resource metric.
+- Fixed-replica fallback when autoscaling is disabled.
+- Pinned Metrics Server Kind validation covering live HPA activation, upgrade,
+  rollback, and removal.
 
 The immediate focus is runtime compatibility operations: automated runtime
 version proposals, an explicit compatibility matrix, release recovery
@@ -48,9 +54,9 @@ runbooks, and validation across supported Kubernetes minor versions.
 
 ## Milestone 3 — Optional platform integrations
 
-**Status:** Planned
+**Status:** In Progress
 
-- Configurable HorizontalPodAutoscaler support after runtime metrics exist.
+- [x] Configurable HorizontalPodAutoscaler support after runtime metrics exist.
 - Optional NetworkPolicy after supported network contracts are defined.
 - Optional ServiceMonitor after observability endpoints stabilize.
 - Optional Ingress integration without owning certificate issuance.

--- a/scripts/chart-smoke-test.sh
+++ b/scripts/chart-smoke-test.sh
@@ -9,6 +9,8 @@ context="kind-$cluster"
 namespace="trussium-helm-smoke"
 release="trussium"
 image="${TRUSSIUM_HELM_IMAGE:-trussium:helm-smoke}"
+metrics_server_version="v0.8.1"
+metrics_server_manifest="https://github.com/kubernetes-sigs/metrics-server/releases/download/$metrics_server_version/components.yaml"
 values="$(mktemp)"
 headers="$(mktemp)"
 body="$(mktemp)"
@@ -47,6 +49,31 @@ assert_equal() {
     fi
 }
 
+wait_for_autoscaling() {
+    attempt=0
+    while [ "$attempt" -lt 90 ]; do
+        ready_replicas="$(kubectl --context "$context" --namespace "$namespace" \
+            get deployment trussium -o jsonpath='{.status.readyReplicas}')"
+        scaling_active="$(kubectl --context "$context" --namespace "$namespace" \
+            get horizontalpodautoscaler/trussium \
+            -o jsonpath='{.status.conditions[?(@.type=="ScalingActive")].status}')"
+
+        if [ "$ready_replicas" = "2" ] && [ "$scaling_active" = "True" ]; then
+            return
+        fi
+
+        attempt=$((attempt + 1))
+        sleep 2
+    done
+
+    kubectl --context "$context" --namespace "$namespace" \
+        get deployment,pods,horizontalpodautoscaler >&2
+    kubectl --context "$context" --namespace "$namespace" \
+        describe horizontalpodautoscaler trussium >&2
+    echo "Helm-managed horizontal autoscaling did not become active within 180 seconds" >&2
+    exit 1
+}
+
 for command_name in docker kind kubectl helm curl python3; do
     command -v "$command_name" >/dev/null 2>&1 || {
         echo "$command_name is required for the Helm smoke test" >&2
@@ -67,6 +94,13 @@ fi
 docker build --quiet --tag "$image" "$runtime_source"
 kind load docker-image "$image" --name "$cluster"
 
+kubectl --context "$context" apply -f "$metrics_server_manifest"
+kubectl --context "$context" -n kube-system patch deployment metrics-server \
+    --type=json \
+    --patch='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
+kubectl --context "$context" -n kube-system rollout status deployment/metrics-server \
+    --timeout=180s
+
 cat >"$values" <<EOF
 image:
   repository: ${image%:*}
@@ -82,9 +116,21 @@ helm --kube-context "$context" install "$release" "$repository_root/charts/truss
     --namespace "$namespace" --create-namespace --values "$values" --wait --timeout 180s
 kubectl --context "$context" --namespace "$namespace" rollout status deployment/trussium \
     --timeout=180s
+wait_for_autoscaling
 
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deployment trussium \
     -o jsonpath='{.status.readyReplicas}')" "2" "ready replicas after install"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" \
+    get horizontalpodautoscaler trussium -o jsonpath='{.spec.minReplicas}')" \
+    "2" "minimum replicas"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" \
+    get horizontalpodautoscaler trussium -o jsonpath='{.spec.maxReplicas}')" \
+    "10" "maximum replicas"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" \
+    get horizontalpodautoscaler trussium \
+    -o jsonpath='{.spec.metrics[0].containerResource.target.averageUtilization}')" \
+    "70" "target CPU utilization"
+assert_equal "$scaling_active" "True" "active horizontal scaling"
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deployment trussium \
     -o jsonpath='{.spec.template.spec.securityContext.runAsUser}')" "10001" "runtime UID"
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deployment trussium \
@@ -122,16 +168,27 @@ assert_equal "$(cat "$body")" '{"status":"ok"}' "readiness response"
 request_id="$(awk 'tolower($1) == "x-request-id:" {gsub("\r", "", $2); print $2}' "$headers")"
 assert_equal "$request_id" "helm-smoke-1" "request correlation header"
 
+curl --fail --silent --show-error "http://127.0.0.1:$port/metrics" --output "$body"
+grep -q '^trussium_http_requests_active 0\.0$' "$body"
+grep -q '^process_start_time_seconds ' "$body"
+
 kill "$port_forward_pid" >/dev/null 2>&1 || true
 wait "$port_forward_pid" >/dev/null 2>&1 || true
 port_forward_pid=""
 
 helm --kube-context "$context" upgrade "$release" "$repository_root/charts/trussium" \
-    --namespace "$namespace" --values "$values" --set replicaCount=3 --wait --timeout 180s
+    --namespace "$namespace" --values "$values" --set autoscaling.enabled=false \
+    --set replicaCount=3 --wait --timeout 180s
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deployment trussium \
     -o jsonpath='{.status.readyReplicas}')" "3" "ready replicas after upgrade"
+if kubectl --context "$context" --namespace "$namespace" \
+    get horizontalpodautoscaler trussium >/dev/null 2>&1; then
+    echo "HorizontalPodAutoscaler remained after fixed-replica upgrade" >&2
+    exit 1
+fi
 
 helm --kube-context "$context" rollback "$release" 1 --namespace "$namespace" --wait --timeout 180s
+wait_for_autoscaling
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deployment trussium \
     -o jsonpath='{.status.readyReplicas}')" "2" "ready replicas after rollback"
 

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,11 @@
 replicaCount: 3
 image:
-  tag: "0.24.0"
+  tag: "0.25.0"
+autoscaling:
+  enabled: false
+observability:
+  metrics:
+    enabled: false
 imagePullSecrets: []
 fullnameOverride: trussium-custom
 serviceAccount:

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -46,7 +46,7 @@ def test_chart_metadata_tracks_runtime_independently() -> None:
     assert metadata["type"] == "application"
     assert re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])
     assert metadata["version"] == project["project"]["version"]
-    assert metadata["appVersion"] == "0.24.0"
+    assert metadata["appVersion"] == "0.25.0"
     assert metadata["annotations"]["artifacthub.io/operator"] == "false"
 
 
@@ -55,6 +55,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert {document["kind"] for document in documents} == {
         "ConfigMap",
         "Deployment",
+        "HorizontalPodAutoscaler",
         "PodDisruptionBudget",
         "Service",
         "ServiceAccount",
@@ -65,7 +66,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     pod_spec = spec["template"]["spec"]
     container = pod_spec["containers"][0]
 
-    assert spec["replicas"] == 2
+    assert "replicas" not in spec
     assert spec["revisionHistoryLimit"] == 3
     assert spec["strategy"]["rollingUpdate"] == {"maxUnavailable": 0, "maxSurge": 1}
     assert pod_spec["automountServiceAccountToken"] is False
@@ -75,7 +76,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert pod_spec["securityContext"]["runAsGroup"] == 10001
     assert pod_spec["securityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
     assert pod_spec["imagePullSecrets"] == [{"name": "ghcr-credentials"}]
-    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.24.0"
+    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.25.0"
     assert container["ports"][0]["containerPort"] == 9000
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]
@@ -103,10 +104,52 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     budget = resource(documents, "PodDisruptionBudget")
     assert budget["spec"]["maxUnavailable"] == 1
 
+    config_map = resource(documents, "ConfigMap")
+    assert config_map["data"]["TRUSSIUM_OBSERVABILITY__METRICS_ENABLED"] == "true"
+
+    autoscaler = resource(documents, "HorizontalPodAutoscaler")
+    assert autoscaler["apiVersion"] == "autoscaling/v2"
+    assert autoscaler["spec"]["scaleTargetRef"] == {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "name": "trussium",
+    }
+    assert autoscaler["spec"]["minReplicas"] == 2
+    assert autoscaler["spec"]["maxReplicas"] == 10
+    assert autoscaler["spec"]["metrics"] == [
+        {
+            "type": "ContainerResource",
+            "containerResource": {
+                "name": "cpu",
+                "container": "trussium",
+                "target": {"type": "Utilization", "averageUtilization": 70},
+            },
+        }
+    ]
+    assert autoscaler["spec"]["behavior"] == {
+        "scaleUp": {
+            "stabilizationWindowSeconds": 0,
+            "selectPolicy": "Max",
+            "policies": [
+                {"type": "Percent", "value": 100, "periodSeconds": 60},
+                {"type": "Pods", "value": 4, "periodSeconds": 60},
+            ],
+        },
+        "scaleDown": {
+            "stabilizationWindowSeconds": 300,
+            "selectPolicy": "Min",
+            "policies": [
+                {"type": "Percent", "value": 25, "periodSeconds": 60},
+                {"type": "Pods", "value": 1, "periodSeconds": 60},
+            ],
+        },
+    }
+
 
 def test_custom_values_render_supported_integrations() -> None:
     documents = render("--values", str(CUSTOM_VALUES))
     assert not any(document["kind"] == "ServiceAccount" for document in documents)
+    assert not any(document["kind"] == "HorizontalPodAutoscaler" for document in documents)
 
     deployment = resource(documents, "Deployment")
     assert deployment["metadata"]["name"] == "trussium-custom"
@@ -131,6 +174,9 @@ def test_custom_values_render_supported_integrations() -> None:
     assert service["spec"]["type"] == "LoadBalancer"
     assert service["spec"]["ports"][0]["port"] == 8080
     assert service["metadata"]["annotations"]["example.com/service"] == "custom"
+
+    config_map = resource(documents, "ConfigMap")
+    assert config_map["data"]["TRUSSIUM_OBSERVABILITY__METRICS_ENABLED"] == "false"
 
 
 def test_chart_does_not_render_credentials() -> None:
@@ -160,3 +206,47 @@ def test_recreate_strategy_omits_rolling_update_settings() -> None:
     deployment = resource(render("--set", "deploymentStrategy.type=Recreate"), "Deployment")
 
     assert deployment["spec"]["strategy"] == {"type": "Recreate"}
+
+
+def test_schema_rejects_invalid_autoscaling_target() -> None:
+    result = run_helm(
+        "template",
+        "trussium",
+        str(CHART),
+        "--set",
+        "autoscaling.targetCPUUtilizationPercentage=0",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "targetCPUUtilizationPercentage" in result.stderr
+    assert "Must be greater than or equal to 1" in result.stderr
+
+
+def test_schema_rejects_unknown_observability_values() -> None:
+    result = run_helm(
+        "template",
+        "trussium",
+        str(CHART),
+        "--set",
+        "observability.metrics.unexpected=true",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "unexpected" in result.stderr
+    assert "Additional property" in result.stderr
+
+
+def test_template_rejects_inverted_autoscaling_bounds() -> None:
+    result = run_helm(
+        "template",
+        "trussium",
+        str(CHART),
+        "--set",
+        "autoscaling.minReplicas=11",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "autoscaling.minReplicas must be less than or equal" in result.stderr


### PR DESCRIPTION
Closes #7

## Summary

- Update the official chart to runtime v0.25.0 and enable its Prometheus-compatible metrics endpoint by default.
- Add a schema-validated `autoscaling/v2` HorizontalPodAutoscaler matching the released runtime production contract.
- Let the HPA own Deployment scale by default while preserving `replicaCount` for fixed operation when autoscaling is disabled.
- Extend the real Kind lifecycle through live resource metrics, autoscaling, fixed-scale upgrade, autoscaling rollback, runtime metrics, and uninstall.
- Document chart/runtime compatibility, prerequisites, tuning, ownership, and the runtime/operator boundary.

## Motivation

Runtime v0.25.0 delivers production runtime metrics and conservative horizontal autoscaling, while chart v0.1.0 still targets runtime v0.24.0 and declares a static replica count. The chart needs to carry the newly released Kubernetes contract into its configurable Helm distribution without bundling a monitoring stack or the future operator.

Container CPU remains the portable default because it uses Kubernetes resource Metrics API and the existing runtime CPU request. Runtime Prometheus-compatible metrics are enabled for operators and future custom-metric integrations, but the chart does not install Prometheus, Prometheus Adapter, or monitoring custom resources.

## Implementation

- Set chart `appVersion`, default image resolution, CI runtime checkout, fixtures, labels, and notes to runtime v0.25.0.
- Add `observability.metrics.enabled` and render `TRUSSIUM_OBSERVABILITY__METRICS_ENABLED` through the non-secret ConfigMap.
- Add an `autoscaling` value group with enablement, replica bounds, CPU target, and complete scale behavior.
- Render an `autoscaling/v2` HPA targeting 70% average CPU utilization for the named `trussium` container.
- Default to two minimum and ten maximum replicas, 100% or four-pod per-minute scale-up, and 300-second stabilized scale-down limited to 25% or one pod per minute.
- Omit Deployment `spec.replicas` while autoscaling is enabled; restore `replicaCount` when it is disabled.
- Reject invalid CPU targets, unknown observability settings, invalid scaling rules, and inverted replica bounds.
- Install pinned Metrics Server v0.8.1 in the Kind lifecycle and require `ScalingActive=True` with two ready replicas.
- Upgrade the live release to autoscaling-disabled fixed three-replica mode, verify HPA removal, then rollback and require active autoscaling at the two-replica floor.
- Exercise `/metrics`, health, request correlation, security, disruption protection, packaging, and removal.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy tests`
- `uv run pytest` — 9 passed
- `scripts/helm-validate.sh`
- `scripts/chart-package.sh`
- `TRUSSIUM_RUNTIME_SOURCE=../trussium-runtime-docs scripts/chart-smoke-test.sh`
- `git diff --check`

## Manual validation

- Rendered default values and confirmed an `autoscaling/v2` HPA, runtime v0.25.0 image, enabled metrics configuration, and no Deployment replica field.
- Rendered autoscaling-disabled values and confirmed HPA omission plus the requested fixed replica count.
- Created a disposable Kind v1.36.1 cluster and installed pinned Metrics Server v0.8.1.
- Installed the chart and confirmed two ready runtime pods, `ScalingActive=True`, live named-container CPU calculation, a 70% target, HPA bounds, hardened security, and disruption protection.
- Confirmed `/health/ready`, request correlation, `trussium_http_requests_active`, and Linux process metrics through the chart Service.
- Upgraded to fixed three-replica mode and confirmed the HPA was removed.
- Rolled back and confirmed the HPA returned, became active, and restored the two-replica floor.
- Uninstalled the release and confirmed the Deployment was removed.

## Compatibility

- Chart `0.2.x` targets runtime `0.25.x`; chart `0.1.x` remains the runtime `0.24.x` line.
- Kubernetes 1.25+ and Helm 3.12+ remain supported.
- Default autoscaling requires a working Kubernetes resource Metrics API, commonly supplied by Metrics Server.
- Operators without a Metrics API can set `autoscaling.enabled=false` and continue using `replicaCount`.
- The default HPA does not depend on Prometheus, Prometheus Adapter, or runtime custom metrics.
- Existing provider Secret, image-pull Secret, health, security, resource, rollout, disruption, and shutdown values remain compatible.
- The chart still installs the Trussium runtime only and does not install `trussium-operator`.

## Risks and mitigations

- Default scale ownership changes from a fixed Deployment field to the HPA; conditional rendering prevents the two controllers from competing.
- Conservative scale velocity and a five-minute downscale stabilization window reduce replica thrashing after transient demand.
- The named-container CPU target prevents future sidecars from altering the runtime scaling signal.
- Strict schema validation bounds CPU targets, policy periods, policy values, and stabilization windows before installation.
- A template guard rejects minimum replica counts above the maximum, which JSON Schema cannot express directly across sibling values.
- The live Kind lifecycle proves both autoscaled and fixed-scale modes, plus the transition and rollback between them.
- Metrics Server is a documented prerequisite and is installed only in the disposable validation cluster, never by the chart.

## Documentation

- Repository README compatibility matrix, Metrics API prerequisite, autoscaling configuration, fixed-scale fallback, and runtime metrics guidance.
- Complete chart value reference and autoscaling ownership semantics.
- Installation notes for HPA status and runtime metrics.
- Chart roadmap marks runtime metrics and configurable HPA integration delivered.
- CI compatibility target updated to runtime tag v0.25.0.

## Checklist

- [x] Issue confirmed before implementation
- [x] Fresh feature branch created from updated `main`
- [x] Runtime v0.25.0 compatibility applied completely
- [x] HPA defaults match the released runtime production contract
- [x] Fixed-replica fallback preserved and tested
- [x] Strict value schema and render tests completed
- [x] Ruff, formatting, strict MyPy, Pytest, Helm lint, and packaging pass
- [x] Live Kind metrics, autoscaling, upgrade, rollback, and uninstall pass
- [x] Complete chart roadmap and compatibility documentation updated
- [x] Conventional Commit used
