### PR TITLE
Add runtime v0.26.0 OpenTelemetry configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: trussiumhq/trussium
-          ref: v0.25.0
+          ref: v0.26.0
           path: runtime
 
       - name: Install Helm

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The chart defaults to the compatible runtime release in `Chart.yaml`'s
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
+| `0.3.x` | `0.26.x` | `>=1.25` |
 | `0.2.x` | `0.25.x` | `>=1.25` |
 | `0.1.x` | `0.24.x` | `>=1.25` |
 
@@ -146,6 +147,14 @@ resources:
 timeouts:
   providerRequestSeconds: 90
   streamIdleSeconds: 45
+
+observability:
+  tracing:
+    enabled: true
+    serviceName: trussium
+    sampleRatio: 0.1
+    otlpTracesEndpoint: http://otel-collector.observability.svc:4318/v1/traces
+    otlpExportTimeoutSeconds: 5
 ```
 
 The chart enables runtime metrics at `/metrics` and CPU-based horizontal
@@ -163,6 +172,16 @@ bounds and target instead. See the
 [runtime metrics guide](https://github.com/trussiumhq/trussium/blob/main/docs/METRICS.md)
 for the bounded Prometheus-compatible metric contract and optional custom
 metrics extension point.
+
+OpenTelemetry tracing is disabled by default. The chart can render runtime
+trace enablement, service name, parent-based sample ratio, OTLP HTTP/protobuf
+traces endpoint, and export timeout, but it does not install a collector or
+tracing backend. Supply a collector endpoint reachable from runtime pods and
+choose sampling and retention policies appropriate to the cluster. Do not put
+collector credentials in `extraConfig`; use an organization-managed network
+or secret-based integration outside the chart. See the
+[runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
+for span, privacy, lifecycle, and current propagation contracts.
 
 The complete value reference is in the
 [chart README](charts/trussium/README.md). `values.schema.json` rejects unknown
@@ -220,10 +239,10 @@ scripts/helm-validate.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.25.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.26.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
-autoscaling, runtime metrics, readiness, HTTP request correlation, fixed-scale
-upgrade, autoscaling rollback, and uninstall:
+autoscaling, runtime metrics, tracing configuration, readiness, HTTP request
+correlation, fixed-scale upgrade, autoscaling rollback, and uninstall:
 
 ```bash
 TRUSSIUM_RUNTIME_SOURCE=../trussium scripts/chart-smoke-test.sh

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.2.0
-appVersion: "0.25.0"
+appVersion: "0.26.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -34,6 +34,11 @@ default compatible runtime image.
 | `timeouts.providerRequestSeconds` | `60` | Provider request deadline. |
 | `timeouts.streamIdleSeconds` | `30` | Streaming event idle deadline. |
 | `observability.metrics.enabled` | `true` | Expose runtime metrics at `/metrics`. |
+| `observability.tracing.enabled` | `false` | Enable runtime OpenTelemetry tracing and OTLP export. |
+| `observability.tracing.serviceName` | `trussium` | OpenTelemetry `service.name`. |
+| `observability.tracing.sampleRatio` | `1.0` | Parent-based root sampling probability from zero through one. |
+| `observability.tracing.otlpTracesEndpoint` | `http://127.0.0.1:4318/v1/traces` | Full OTLP HTTP/protobuf traces endpoint. |
+| `observability.tracing.otlpExportTimeoutSeconds` | `10` | Positive OTLP export request timeout. |
 | `autoscaling.enabled` | `true` | Create the runtime HorizontalPodAutoscaler. |
 | `autoscaling.minReplicas` | `2` | Autoscaling availability floor. |
 | `autoscaling.maxReplicas` | `10` | Autoscaling replica ceiling. |
@@ -80,3 +85,33 @@ replicaCount: 3
 Runtime metrics remain independently configurable through
 `observability.metrics.enabled`. The chart does not install Prometheus,
 Prometheus Adapter, ServiceMonitor, or other monitoring resources.
+
+## OpenTelemetry tracing
+
+Tracing remains disabled by default because the chart does not install an
+OpenTelemetry Collector or tracing backend. Enable it only after supplying an
+endpoint reachable from the runtime pod network:
+
+```yaml
+observability:
+  tracing:
+    enabled: true
+    serviceName: trussium
+    sampleRatio: 0.1
+    otlpTracesEndpoint: http://otel-collector.observability.svc:4318/v1/traces
+    otlpExportTimeoutSeconds: 5
+```
+
+The settings are rendered into the non-secret ConfigMap. The schema requires a
+non-blank service name, a sample ratio from `0` through `1`, an HTTP or HTTPS
+endpoint, and a positive timeout. The loopback default points to the runtime
+pod itself and is safe only while tracing is disabled or when a collector
+sidecar intentionally listens there.
+
+The chart does not accept OTLP credentials. Do not place authentication values
+in `extraConfig`; integrate collector authentication through organization-owned
+network and secret controls. The runtime excludes health and metrics traffic
+and does not attach prompts, bodies, credentials, query strings, raw URLs, or
+exception messages to spans. See the
+[runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
+for the complete contract.

--- a/charts/trussium/templates/NOTES.txt
+++ b/charts/trussium/templates/NOTES.txt
@@ -14,5 +14,11 @@ Reach the runtime locally:
 {{- if .Values.observability.metrics.enabled }}
   curl http://127.0.0.1:9000/metrics
 {{- end }}
+{{- if .Values.observability.tracing.enabled }}
+
+OpenTelemetry trace export is enabled for service {{ .Values.observability.tracing.serviceName }}.
+Confirm that the runtime network can reach {{ .Values.observability.tracing.otlpTracesEndpoint }}.
+This chart does not install an OpenTelemetry Collector or tracing backend.
+{{- end }}
 
 This chart installs the Trussium runtime only. It does not install trussium-operator.

--- a/charts/trussium/templates/configmap.yaml
+++ b/charts/trussium/templates/configmap.yaml
@@ -12,6 +12,11 @@ data:
   TRUSSIUM_TIMEOUTS__PROVIDER_REQUEST_SECONDS: {{ .Values.timeouts.providerRequestSeconds | quote }}
   TRUSSIUM_TIMEOUTS__STREAM_IDLE_SECONDS: {{ .Values.timeouts.streamIdleSeconds | quote }}
   TRUSSIUM_OBSERVABILITY__METRICS_ENABLED: {{ .Values.observability.metrics.enabled | quote }}
+  TRUSSIUM_OBSERVABILITY__TRACING_ENABLED: {{ .Values.observability.tracing.enabled | quote }}
+  TRUSSIUM_OBSERVABILITY__TRACING_SERVICE_NAME: {{ .Values.observability.tracing.serviceName | quote }}
+  TRUSSIUM_OBSERVABILITY__TRACING_SAMPLE_RATIO: {{ .Values.observability.tracing.sampleRatio | quote }}
+  TRUSSIUM_OBSERVABILITY__OTLP_TRACES_ENDPOINT: {{ .Values.observability.tracing.otlpTracesEndpoint | quote }}
+  TRUSSIUM_OBSERVABILITY__OTLP_EXPORT_TIMEOUT_SECONDS: {{ .Values.observability.tracing.otlpExportTimeoutSeconds | quote }}
   {{- range $key, $value := .Values.extraConfig }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/trussium/values.schema.json
+++ b/charts/trussium/values.schema.json
@@ -98,7 +98,7 @@
     "observability": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["metrics"],
+      "required": ["metrics", "tracing"],
       "properties": {
         "metrics": {
           "type": "object",
@@ -106,6 +106,39 @@
           "required": ["enabled"],
           "properties": {
             "enabled": {"type": "boolean"}
+          }
+        },
+        "tracing": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "serviceName",
+            "sampleRatio",
+            "otlpTracesEndpoint",
+            "otlpExportTimeoutSeconds"
+          ],
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "serviceName": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": ".*\\S.*"
+            },
+            "sampleRatio": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "otlpTracesEndpoint": {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^https?://\\S+$"
+            },
+            "otlpExportTimeoutSeconds": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            }
           }
         }
       }

--- a/charts/trussium/values.yaml
+++ b/charts/trussium/values.yaml
@@ -52,6 +52,12 @@ timeouts:
 observability:
   metrics:
     enabled: true
+  tracing:
+    enabled: false
+    serviceName: trussium
+    sampleRatio: 1.0
+    otlpTracesEndpoint: http://127.0.0.1:4318/v1/traces
+    otlpExportTimeoutSeconds: 10
 
 autoscaling:
   enabled: true

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.25.0
+The production Helm chart now carries the validated Trussium v0.26.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.
@@ -27,6 +27,12 @@ Kubernetes contract into an independently released distribution:
 - Fixed-replica fallback when autoscaling is disabled.
 - Pinned Metrics Server Kind validation covering live HPA activation, upgrade,
   rollback, and removal.
+- OpenTelemetry tracing values for enablement, service identity, parent-based
+  sampling, OTLP HTTP/protobuf endpoint, and export timeout.
+- Tracing-disabled defaults until an operator supplies a reachable collector
+  with an intentional sampling and retention policy.
+- Schema, render, package, and Kind upgrade/rollback validation for the full
+  tracing configuration contract without chart-owned collector resources.
 
 The immediate focus is runtime compatibility operations: automated runtime
 version proposals, an explicit compatibility matrix, release recovery
@@ -57,6 +63,7 @@ runbooks, and validation across supported Kubernetes minor versions.
 **Status:** In Progress
 
 - [x] Configurable HorizontalPodAutoscaler support after runtime metrics exist.
+- [x] Configurable OpenTelemetry runtime tracing after instrumentation exists.
 - Optional NetworkPolicy after supported network contracts are defined.
 - Optional ServiceMonitor after observability endpoints stabilize.
 - Optional Ingress integration without owning certificate issuance.

--- a/scripts/chart-smoke-test.sh
+++ b/scripts/chart-smoke-test.sh
@@ -138,6 +138,12 @@ assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deploy
     "true" "read-only root filesystem"
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get poddisruptionbudget trussium \
     -o jsonpath='{.spec.maxUnavailable}')" "1" "maximum unavailable pods"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__TRACING_ENABLED}')" \
+    "false" "default tracing enablement"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__TRACING_SERVICE_NAME}')" \
+    "trussium" "default tracing service name"
 
 port="$(python3 -c 'import socket; sock = socket.socket(); sock.bind(("127.0.0.1", 0)); print(sock.getsockname()[1]); sock.close()')"
 kubectl --context "$context" --namespace "$namespace" port-forward service/trussium \
@@ -178,7 +184,11 @@ port_forward_pid=""
 
 helm --kube-context "$context" upgrade "$release" "$repository_root/charts/trussium" \
     --namespace "$namespace" --values "$values" --set autoscaling.enabled=false \
-    --set replicaCount=3 --wait --timeout 180s
+    --set replicaCount=3 --set observability.tracing.enabled=true \
+    --set observability.tracing.serviceName=trussium-upgraded \
+    --set-json observability.tracing.sampleRatio=0.25 \
+    --set-string observability.tracing.otlpTracesEndpoint=http://collector.example:4318/v1/traces \
+    --set-json observability.tracing.otlpExportTimeoutSeconds=2.5 --wait --timeout 180s
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deployment trussium \
     -o jsonpath='{.status.readyReplicas}')" "3" "ready replicas after upgrade"
 if kubectl --context "$context" --namespace "$namespace" \
@@ -186,11 +196,29 @@ if kubectl --context "$context" --namespace "$namespace" \
     echo "HorizontalPodAutoscaler remained after fixed-replica upgrade" >&2
     exit 1
 fi
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__TRACING_ENABLED}')" \
+    "true" "upgraded tracing enablement"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__TRACING_SERVICE_NAME}')" \
+    "trussium-upgraded" "upgraded tracing service name"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__TRACING_SAMPLE_RATIO}')" \
+    "0.25" "upgraded trace sample ratio"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__OTLP_TRACES_ENDPOINT}')" \
+    "http://collector.example:4318/v1/traces" "upgraded OTLP traces endpoint"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__OTLP_EXPORT_TIMEOUT_SECONDS}')" \
+    "2.5" "upgraded OTLP export timeout"
 
 helm --kube-context "$context" rollback "$release" 1 --namespace "$namespace" --wait --timeout 180s
 wait_for_autoscaling
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deployment trussium \
     -o jsonpath='{.status.readyReplicas}')" "2" "ready replicas after rollback"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__TRACING_ENABLED}')" \
+    "false" "tracing enablement after rollback"
 
 helm --kube-context "$context" uninstall "$release" --namespace "$namespace" --wait
 if kubectl --context "$context" --namespace "$namespace" get deployment trussium >/dev/null 2>&1; then

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,11 +1,17 @@
 replicaCount: 3
 image:
-  tag: "0.25.0"
+  tag: "0.26.0"
 autoscaling:
   enabled: false
 observability:
   metrics:
     enabled: false
+  tracing:
+    enabled: true
+    serviceName: trussium-custom
+    sampleRatio: 0.25
+    otlpTracesEndpoint: https://collector.example/v1/traces
+    otlpExportTimeoutSeconds: 2.5
 imagePullSecrets: []
 fullnameOverride: trussium-custom
 serviceAccount:

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -6,6 +6,7 @@ import tomllib
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 import yaml
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -46,7 +47,7 @@ def test_chart_metadata_tracks_runtime_independently() -> None:
     assert metadata["type"] == "application"
     assert re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])
     assert metadata["version"] == project["project"]["version"]
-    assert metadata["appVersion"] == "0.25.0"
+    assert metadata["appVersion"] == "0.26.0"
     assert metadata["annotations"]["artifacthub.io/operator"] == "false"
 
 
@@ -76,7 +77,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert pod_spec["securityContext"]["runAsGroup"] == 10001
     assert pod_spec["securityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
     assert pod_spec["imagePullSecrets"] == [{"name": "ghcr-credentials"}]
-    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.25.0"
+    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.26.0"
     assert container["ports"][0]["containerPort"] == 9000
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]
@@ -106,6 +107,14 @@ def test_default_render_preserves_production_runtime_contract() -> None:
 
     config_map = resource(documents, "ConfigMap")
     assert config_map["data"]["TRUSSIUM_OBSERVABILITY__METRICS_ENABLED"] == "true"
+    assert config_map["data"]["TRUSSIUM_OBSERVABILITY__TRACING_ENABLED"] == "false"
+    assert config_map["data"]["TRUSSIUM_OBSERVABILITY__TRACING_SERVICE_NAME"] == "trussium"
+    assert config_map["data"]["TRUSSIUM_OBSERVABILITY__TRACING_SAMPLE_RATIO"] == "1"
+    assert (
+        config_map["data"]["TRUSSIUM_OBSERVABILITY__OTLP_TRACES_ENDPOINT"]
+        == "http://127.0.0.1:4318/v1/traces"
+    )
+    assert config_map["data"]["TRUSSIUM_OBSERVABILITY__OTLP_EXPORT_TIMEOUT_SECONDS"] == "10"
 
     autoscaler = resource(documents, "HorizontalPodAutoscaler")
     assert autoscaler["apiVersion"] == "autoscaling/v2"
@@ -177,6 +186,14 @@ def test_custom_values_render_supported_integrations() -> None:
 
     config_map = resource(documents, "ConfigMap")
     assert config_map["data"]["TRUSSIUM_OBSERVABILITY__METRICS_ENABLED"] == "false"
+    assert config_map["data"]["TRUSSIUM_OBSERVABILITY__TRACING_ENABLED"] == "true"
+    assert config_map["data"]["TRUSSIUM_OBSERVABILITY__TRACING_SERVICE_NAME"] == "trussium-custom"
+    assert config_map["data"]["TRUSSIUM_OBSERVABILITY__TRACING_SAMPLE_RATIO"] == "0.25"
+    assert (
+        config_map["data"]["TRUSSIUM_OBSERVABILITY__OTLP_TRACES_ENDPOINT"]
+        == "https://collector.example/v1/traces"
+    )
+    assert config_map["data"]["TRUSSIUM_OBSERVABILITY__OTLP_EXPORT_TIMEOUT_SECONDS"] == "2.5"
 
 
 def test_chart_does_not_render_credentials() -> None:
@@ -229,13 +246,41 @@ def test_schema_rejects_unknown_observability_values() -> None:
         "trussium",
         str(CHART),
         "--set",
-        "observability.metrics.unexpected=true",
+        "observability.tracing.unexpected=true",
         check=False,
     )
 
     assert result.returncode != 0
     assert "unexpected" in result.stderr
     assert "Additional property" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("flag", "setting", "value"),
+    [
+        ("--set-string", "serviceName", ""),
+        ("--set", "sampleRatio", "-0.1"),
+        ("--set", "sampleRatio", "1.1"),
+        ("--set-string", "otlpTracesEndpoint", "grpc://collector:4317"),
+        ("--set", "otlpExportTimeoutSeconds", "0"),
+    ],
+)
+def test_schema_rejects_invalid_tracing_values(
+    flag: str,
+    setting: str,
+    value: str,
+) -> None:
+    result = run_helm(
+        "template",
+        "trussium",
+        str(CHART),
+        flag,
+        f"observability.tracing.{setting}={value}",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert setting in result.stderr
 
 
 def test_template_rejects_inverted_autoscaling_bounds() -> None:


### PR DESCRIPTION
Closes #9

## Summary

- Update the official chart’s default compatible runtime from v0.25.0 to v0.26.0.
- Add schema-validated OpenTelemetry tracing values for enablement, service identity, sampling, OTLP HTTP/protobuf endpoint, and export timeout.
- Preserve safe default-disabled tracing while rendering the complete runtime environment contract through the non-secret ConfigMap.
- Validate default, custom, invalid, package, install, tracing-enabled upgrade, rollback, and uninstall behavior.
- Document collector ownership, privacy boundaries, compatibility, configuration, and the complete chart roadmap.

## Motivation

Runtime v0.26.0 adds app-scoped OpenTelemetry instrumentation, inbound W3C trace-context extraction, complete HTTP/capability/provider spans, OTLP HTTP/protobuf export, trace-correlated structured logs, privacy-aware attributes, and clean exporter shutdown. Chart v0.2.0 still targets runtime v0.25.0 and cannot configure those settings through its typed value surface.

The chart should expose the released runtime contract without assuming an operator’s collector topology, capacity, authentication, sampling, or retention policy. Tracing therefore remains opt-in, and collector or backend installation remains outside the chart boundary.

## Implementation

- Update `appVersion`, the default runtime image, CI runtime checkout, custom fixture, compatibility documentation, and Kind validation to runtime v0.26.0.
- Add `observability.tracing.enabled` with a default of `false`.
- Add `observability.tracing.serviceName` with the runtime default `trussium`.
- Add `observability.tracing.sampleRatio` with a validated inclusive range from zero through one.
- Add `observability.tracing.otlpTracesEndpoint` with URI and HTTP/HTTPS schema validation.
- Add `observability.tracing.otlpExportTimeoutSeconds` with a strictly positive numeric constraint.
- Require the complete tracing object and reject unknown tracing fields through strict JSON Schema.
- Render all five settings through the established `TRUSSIUM_OBSERVABILITY__...` non-secret ConfigMap keys.
- Extend default rendering assertions for the disabled contract and custom rendering assertions for every configured value.
- Add invalid-value coverage for blank service names, negative and greater-than-one sample ratios, non-HTTP endpoints, non-positive timeouts, and unknown properties.
- Extend release notes to identify enabled tracing, the configured service and endpoint, and the fact that the chart does not install a collector or backend.
- Extend the disposable Kind lifecycle to verify tracing-disabled installation, a tracing-enabled fixed-scale upgrade, exact ConfigMap values, rollback to tracing disabled, and uninstall.
- Preserve metrics, HPA, fixed-replica, security, provider Secret, health, graceful-shutdown, and runtime-only ownership contracts unchanged.

## Testing

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mypy tests`
- `.venv/bin/pytest -q` — 14 passed
- `scripts/helm-validate.sh`
- `scripts/chart-package.sh`
- `TRUSSIUM_RUNTIME_SOURCE=../trussium-runtime-docs scripts/chart-smoke-test.sh`
- `git diff --check`

## Manual validation

- Rendered the default chart and confirmed runtime image `ghcr.io/trussiumhq/trussium:0.26.0` plus all five tracing environment values.
- Confirmed default tracing renders as disabled with service `trussium`, sample ratio `1`, loopback OTLP traces endpoint, and 10-second timeout.
- Confirmed the chart renders no Secret, OpenTelemetry Collector, tracing backend, monitoring custom resource, or operator resource.
- Created a disposable Kind v1.36.1 cluster, built and loaded the neighboring released runtime v0.26.0 source, and installed pinned Metrics Server v0.8.1.
- Confirmed the initial Helm installation reached two ready replicas with `ScalingActive=True`, health, metrics, request correlation, and tracing disabled.
- Upgraded to three fixed replicas with tracing enabled, service `trussium-upgraded`, sample ratio `0.25`, endpoint `http://collector.example:4318/v1/traces`, and timeout `2.5`.
- Confirmed every upgraded tracing value exactly in the live ConfigMap without requiring a collector for idle health operation.
- Rolled back and confirmed autoscaling returned with two ready replicas and tracing returned to disabled.
- Uninstalled the release and confirmed the Deployment was removed.

## Compatibility

- Chart source now defaults to runtime v0.26.0 and the next chart release line is documented as `0.3.x` → runtime `0.26.x`.
- Existing values and rendered contracts remain backward compatible; the new required tracing object is fully populated by chart defaults.
- Tracing stays disabled unless explicitly enabled, so existing installations do not create exporter traffic after upgrade.
- Metrics remain enabled and the production HPA remains enabled by default.
- The chart still deploys only the Trussium runtime and does not install `trussium-operator`.
- The chart does not install Prometheus, Prometheus Adapter, an OpenTelemetry Collector, tracing backend, ServiceMonitor, PodMonitor, or credentials.
- Overriding `image.tag` remains supported with operator-owned compatibility validation.
- Kubernetes 1.25+, Helm 3.12+, port 9000, the hardened security context, existing Secret integration, and termination timing remain unchanged.

## Risks and mitigations

- Tracing is disabled by default because no universal collector endpoint or sampling policy exists.
- The loopback endpoint is harmless while disabled and is documented as suitable only for an intentional sidecar collector when enabled.
- Strict schema validation rejects misspelled fields, malformed URI schemes, blank identity, invalid sampling, and invalid timeouts before resource installation.
- The endpoint and settings are non-secret; documentation explicitly prohibits placing collector credentials in `extraConfig`.
- The chart does not add collector resources, RBAC, ports, Secrets, or monitoring CRDs, preserving its runtime-only ownership boundary.
- Exact live ConfigMap assertions across install, upgrade, and rollback catch Helm typing and persistence regressions.
- Runtime v0.26.0’s own package, container, OTLP, and Kubernetes release validation provides the application-side compatibility baseline.
- The chart’s real Kind lifecycle validates the combined runtime image and Kubernetes behavior rather than relying only on static rendering.

## Documentation

- Root README compatibility matrix adds the `0.3.x` chart and `0.26.x` runtime line.
- Root configuration guidance adds a production tracing example and links the runtime tracing contract.
- Chart value reference documents every new tracing setting and default.
- Chart operations guidance covers collector reachability, loopback behavior, schema constraints, secret ownership, privacy boundaries, and current propagation scope.
- Release notes surface enabled tracing without claiming collector ownership.
- Canonical chart roadmap marks runtime v0.26.0 tracing configuration delivered while retaining compatibility automation as the immediate focus.

## Checklist

- [x] Issue confirmed before implementation
- [x] Fresh feature branch created from updated `main`
- [x] Runtime v0.26.0 release and multi-platform image verified first
- [x] Tracing remains disabled by default
- [x] Complete tracing value surface is schema validated
- [x] Existing metrics, autoscaling, security, Secret, and shutdown contracts preserved
- [x] No collector, backend, credential, monitoring CRD, or operator resources added
- [x] Ruff, formatting, strict MyPy, Pytest, Helm lint/render, and packaging pass
- [x] Complete Kind install, tracing upgrade, rollback, and uninstall validation passes
- [x] Canonical chart roadmap updated completely
- [x] Conventional Commit used
