### PR TITLE
Update chart for runtime v0.27.0 distributed tracing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: trussiumhq/trussium
-          ref: v0.26.0
+          ref: v0.27.0
           path: runtime
 
       - name: Install Helm

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ The chart defaults to the compatible runtime release in `Chart.yaml`'s
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
-| `0.3.x` | `0.26.x` | `>=1.25` |
+| `0.3.1` | `0.27.x` | `>=1.25` |
+| `0.3.0` | `0.26.x` | `>=1.25` |
 | `0.2.x` | `0.25.x` | `>=1.25` |
 | `0.1.x` | `0.24.x` | `>=1.25` |
 
@@ -179,9 +180,16 @@ traces endpoint, and export timeout, but it does not install a collector or
 tracing backend. Supply a collector endpoint reachable from runtime pods and
 choose sampling and retention policies appropriate to the cluster. Do not put
 collector credentials in `extraConfig`; use an organization-managed network
-or secret-based integration outside the chart. See the
+or secret-based integration outside the chart.
+
+Runtime v0.27.0 propagates W3C `traceparent` and optional `tracestate` from the
+active provider span to supported OpenAI and Ollama-compatible JSON and SSE
+requests. It does not propagate baggage, request IDs, arbitrary inbound
+headers, prompts, completions, bodies, or credentials as tracing metadata. A
+downstream provider or gateway must extract W3C Trace Context and create its
+own span; the chart does not install or instrument that receiver. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
-for span, privacy, lifecycle, and current propagation contracts.
+for the complete span, privacy, lifecycle, sampling, and propagation contract.
 
 The complete value reference is in the
 [chart README](charts/trussium/README.md). `values.schema.json` rejects unknown
@@ -239,7 +247,7 @@ scripts/helm-validate.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.26.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.27.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
 autoscaling, runtime metrics, tracing configuration, readiness, HTTP request
 correlation, fixed-scale upgrade, autoscaling rollback, and uninstall:

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.3.0
-appVersion: "0.26.0"
+appVersion: "0.27.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -112,6 +112,13 @@ The chart does not accept OTLP credentials. Do not place authentication values
 in `extraConfig`; integrate collector authentication through organization-owned
 network and secret controls. The runtime excludes health and metrics traffic
 and does not attach prompts, bodies, credentials, query strings, raw URLs, or
-exception messages to spans. See the
+exception messages to spans.
+
+With runtime v0.27.0, the active provider span is propagated to supported
+OpenAI and Ollama-compatible JSON and SSE requests as W3C `traceparent` and
+optional `tracestate`. Baggage, request IDs, arbitrary inbound headers,
+payloads, and credentials remain behind the runtime privacy boundary. The
+downstream provider or gateway owns W3C extraction and its receiver span; this
+chart does not add downstream instrumentation or resources. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
 for the complete contract.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.26.0
+The production Helm chart now carries the validated Trussium v0.27.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.
@@ -33,6 +33,10 @@ Kubernetes contract into an independently released distribution:
   with an intentional sampling and retention policy.
 - Schema, render, package, and Kind upgrade/rollback validation for the full
   tracing configuration contract without chart-owned collector resources.
+- Runtime v0.27.0 outbound W3C `traceparent` and optional `tracestate`
+  propagation through the existing tracing configuration contract.
+- Explicit runtime privacy boundaries for baggage, request IDs, arbitrary
+  headers, payloads, and credentials, without chart-owned receiver resources.
 
 The immediate focus is runtime compatibility operations: automated runtime
 version proposals, an explicit compatibility matrix, release recovery

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 3
 image:
-  tag: "0.26.0"
+  tag: "0.27.0"
 autoscaling:
   enabled: false
 observability:

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -47,7 +47,7 @@ def test_chart_metadata_tracks_runtime_independently() -> None:
     assert metadata["type"] == "application"
     assert re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])
     assert metadata["version"] == project["project"]["version"]
-    assert metadata["appVersion"] == "0.26.0"
+    assert metadata["appVersion"] == "0.27.0"
     assert metadata["annotations"]["artifacthub.io/operator"] == "false"
 
 
@@ -77,7 +77,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert pod_spec["securityContext"]["runAsGroup"] == 10001
     assert pod_spec["securityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
     assert pod_spec["imagePullSecrets"] == [{"name": "ghcr-credentials"}]
-    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.26.0"
+    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.27.0"
     assert container["ports"][0]["containerPort"] == 9000
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]


### PR DESCRIPTION
Closes #11

## Summary

- Update the official chart's default compatible runtime from v0.26.0 to v0.27.0.
- Advance the empty image.tag default, CI runtime checkout, fixtures, tests, and Kind source validation together.
- Preserve the existing schema-validated OpenTelemetry values and safe tracing-disabled defaults without adding configuration or resources.
- Document v0.27.0 outbound W3C traceparent and optional tracestate propagation plus its privacy and receiver-ownership boundaries.
- Validate the complete install, live autoscaling, tracing-enabled upgrade, rollback, uninstall, and cleanup lifecycle.
- Release the backward-compatible runtime target update on the chart 0.3.1 patch line.

## Motivation

Runtime v0.27.0 completes distributed tracing by propagating the active provider CLIENT span across OpenAI and Ollama-compatible provider requests. Chart v0.3.0 still defaults to runtime v0.26.0 and checks out that tag in compatibility CI, so ordinary installations with an empty image.tag do not receive the released behavior.

The existing chart tracing value surface already enables the runtime correctly. This change should therefore update and validate the compatibility target without adding values, collector ownership, downstream instrumentation, or a chart configuration migration.

## Implementation

- Verify the v0.27.0 GitHub release, wheel, source archive, and published multi-platform runtime image before editing the chart.
- Update Chart.yaml appVersion from 0.26.0 to 0.27.0 while leaving the independently managed source chart version at 0.3.0 for semantic release.
- Update the default rendered image assertion to ghcr.io/trussiumhq/trussium:0.27.0.
- Update the custom image-tag fixture to 0.27.0 while preserving override support.
- Update GitHub Actions to check out runtime tag v0.27.0 for the real Kind lifecycle.
- Update root development guidance so the local Kind test explicitly targets runtime v0.27.0.
- Add an exact chart compatibility-matrix line for chart 0.3.1 and retain historical 0.3.0 to runtime 0.26.x compatibility.
- Document W3C traceparent and optional tracestate propagation for OpenAI and Ollama-compatible JSON and SSE provider calls.
- Document that baggage, request IDs, arbitrary inbound headers, payloads, and credentials do not cross the provider tracing boundary.
- Retain downstream receiver W3C extraction and span creation outside chart ownership.
- Update the complete chart roadmap to record the v0.27.0 compatibility and privacy contract.
- Make no changes to values.yaml, values.schema.json, templates, Kubernetes resources, or runtime environment settings.

## Testing

- uv run ruff check .
- uv run ruff format --check .
- uv run mypy tests
- uv run pytest -q — 14 passed
- uv lock --check
- scripts/helm-validate.sh
- scripts/chart-package.sh
- TRUSSIUM_RUNTIME_SOURCE=../trussium-runtime-docs scripts/chart-smoke-test.sh
- git diff --check

## Manual validation

- Verified runtime release v0.27.0 includes trussium-0.27.0-py3-none-any.whl and trussium-0.27.0.tar.gz.
- Verified ghcr.io/trussiumhq/trussium:0.27.0 as a multi-platform OCI index for Linux AMD64 and ARM64.
- Verified runtime image digest sha256:d38991f4ee8f4e296679638467149474b2c07d7726431f72f63cea880ef6c338.
- Packaged the chart locally and confirmed metadata reports chart version 0.3.0 before release and appVersion 0.27.0.
- Rendered the packaged chart and confirmed the default image is ghcr.io/trussiumhq/trussium:0.27.0.
- Confirmed the default ConfigMap still renders tracing disabled and no Secret, collector, backend, receiver, monitoring CRD, or operator resource is created.
- Created a disposable Kind v1.36.1 cluster and built the released neighboring runtime v0.27.0 source.
- Installed pinned Metrics Server v0.8.1 and confirmed two ready replicas with ScalingActive=True.
- Confirmed health, metrics, hardened security, request correlation, and tracing-disabled defaults.
- Upgraded to three fixed replicas with tracing enabled and confirmed every configured trace setting exactly in the live ConfigMap.
- Rolled back and confirmed autoscaling, two ready replicas, and tracing-disabled behavior returned.
- Uninstalled the release, confirmed removal, and confirmed the disposable cluster was deleted.

## Compatibility

- Chart 0.3.1 defaults to runtime 0.27.x; chart 0.3.0 remains documented with runtime 0.26.x.
- Existing values and JSON Schema remain byte-for-byte unchanged.
- Existing tracing enablement, service name, sample ratio, endpoint, and timeout values remain backward compatible.
- Tracing remains disabled by default, so existing installations do not create exporter or provider trace traffic unless explicitly enabled.
- Empty image.tag now selects runtime v0.27.0; explicit image.tag overrides remain supported with operator-owned compatibility validation.
- Metrics, HPA, fixed replicas, security, provider Secret, health, shutdown, upgrade, rollback, and uninstall behavior remain unchanged.
- Kubernetes 1.25+, Helm 3.12+, port 9000, runtime-only ownership, and independent chart versioning remain unchanged.
- The chart still does not install trussium-operator.

## Risks and mitigations

- The target runtime release and both architecture manifests were verified before chart changes.
- A patch Conventional Commit reflects that the chart value and resource surface is unchanged.
- Deterministic tests bind appVersion, default image rendering, and CI runtime checkout to v0.27.0.
- The complete real Kind lifecycle validates the chart and released runtime together rather than relying only on template rendering.
- Tracing remains opt-in, so the runtime update does not introduce unexpected collector traffic for default installations.
- Privacy documentation explicitly distinguishes trace context from baggage and application metadata.
- The chart does not claim downstream continuity unless the provider or gateway extracts W3C context and owns its receiver span.
- No collector, backend, receiver, credentials, monitoring CRD, or additional RBAC/resource surface is introduced.
- Historical compatibility is retained in the matrix rather than rewriting the meaning of chart v0.3.0.

## Documentation

- Root README compatibility matrix records 0.3.1 to runtime 0.27.x and preserves the 0.3.0 to runtime 0.26.x line.
- Root tracing guidance documents outbound W3C propagation, excluded metadata, and downstream receiver ownership.
- Chart README documents the same operator-facing distributed-tracing contract.
- Development guidance targets v0.27.0 for the complete Kind lifecycle.
- Canonical chart roadmap records runtime v0.27.0 propagation and privacy compatibility.

## Checklist

- [x] Issue confirmed before implementation
- [x] Fresh branch created from updated main
- [x] Runtime v0.27.0 release assets and multi-platform image verified first
- [x] Default appVersion, image rendering, CI checkout, fixtures, and tests updated together
- [x] Existing tracing values and schema preserved unchanged
- [x] Tracing remains disabled by default
- [x] No collector, backend, receiver, Secret, monitoring CRD, or operator resources added
- [x] Ruff, formatting, strict MyPy, Pytest, Helm lint/render, and packaging pass
- [x] Complete Kind install, autoscaling, tracing upgrade, rollback, uninstall, and cleanup pass
- [x] Compatibility matrix and canonical roadmap updated completely
- [x] Conventional Commit used

