### PR TITLE
Update chart for runtime v0.28.0 structured operational logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: trussiumhq/trussium
-          ref: v0.27.0
+          ref: v0.28.0
           path: runtime
 
       - name: Install Helm

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The chart defaults to the compatible runtime release in `Chart.yaml`'s
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
+| `0.3.2` | `0.28.x` | `>=1.25` |
 | `0.3.1` | `0.27.x` | `>=1.25` |
 | `0.3.0` | `0.26.x` | `>=1.25` |
 | `0.2.x` | `0.25.x` | `>=1.25` |
@@ -182,7 +183,7 @@ choose sampling and retention policies appropriate to the cluster. Do not put
 collector credentials in `extraConfig`; use an organization-managed network
 or secret-based integration outside the chart.
 
-Runtime v0.27.0 propagates W3C `traceparent` and optional `tracestate` from the
+Runtime v0.28.0 propagates W3C `traceparent` and optional `tracestate` from the
 active provider span to supported OpenAI and Ollama-compatible JSON and SSE
 requests. It does not propagate baggage, request IDs, arbitrary inbound
 headers, prompts, completions, bodies, or credentials as tracing metadata. A
@@ -190,6 +191,18 @@ downstream provider or gateway must extract W3C Trace Context and create its
 own span; the chart does not install or instrument that receiver. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
 for the complete span, privacy, lifecycle, sampling, and propagation contract.
+
+Runtime v0.28.0 also emits newline-delimited structured operational JSON for
+safe configuration summaries, provider configuration readiness, application
+and server lifecycle, graceful-drain outcomes, invalid configuration, and
+trace-export failures. Provider readiness events describe local configuration;
+they do not probe provider connectivity or change `/health/ready` semantics.
+The runtime excludes credentials, endpoints, payloads, raw settings, rejected
+values, exception messages, and span data from these events. The chart relies
+on the Kubernetes container log stream and does not install a collector,
+shipper, storage backend, dashboard, or alert. See the
+[runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
+for the stable event and privacy contract.
 
 The complete value reference is in the
 [chart README](charts/trussium/README.md). `values.schema.json` rejects unknown
@@ -247,10 +260,11 @@ scripts/helm-validate.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.27.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.28.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
-autoscaling, runtime metrics, tracing configuration, readiness, HTTP request
-correlation, fixed-scale upgrade, autoscaling rollback, and uninstall:
+autoscaling, runtime metrics, tracing configuration, operational startup logs,
+readiness, HTTP request correlation, fixed-scale upgrade, autoscaling rollback,
+and uninstall:
 
 ```bash
 TRUSSIUM_RUNTIME_SOURCE=../trussium scripts/chart-smoke-test.sh

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.3.1
-appVersion: "0.27.0"
+appVersion: "0.28.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -114,7 +114,7 @@ network and secret controls. The runtime excludes health and metrics traffic
 and does not attach prompts, bodies, credentials, query strings, raw URLs, or
 exception messages to spans.
 
-With runtime v0.27.0, the active provider span is propagated to supported
+With runtime v0.28.0, the active provider span is propagated to supported
 OpenAI and Ollama-compatible JSON and SSE requests as W3C `traceparent` and
 optional `tracestate`. Baggage, request IDs, arbitrary inbound headers,
 payloads, and credentials remain behind the runtime privacy boundary. The
@@ -122,3 +122,23 @@ downstream provider or gateway owns W3C extraction and its receiver span; this
 chart does not add downstream instrumentation or resources. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
 for the complete contract.
+
+## Structured operational logs
+
+Runtime v0.28.0 writes bounded newline-delimited JSON events to standard
+output for startup configuration, provider configuration readiness,
+observability enablement, application and server shutdown, graceful-drain
+timeouts, invalid settings, and trace-export failures.
+
+`provider.configuration.ready` and `provider.configuration.unavailable`
+describe whether the runtime constructed a provider capability from local
+configuration. They do not probe network reachability, authenticate a
+credential, inspect a model, or alter the readiness endpoint.
+
+Operational events exclude credentials, provider and collector endpoints,
+payloads, raw settings, rejected values, exception messages, and span data.
+The chart does not add a collector, log shipper, backend, dashboard, alerting
+rule, volume, sidecar, or new value for this contract. Kubernetes platform log
+collection remains operator-owned. See the
+[runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
+for the stable event table and privacy boundary.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.27.0
+The production Helm chart now carries the validated Trussium v0.28.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.
@@ -33,10 +33,15 @@ Kubernetes contract into an independently released distribution:
   with an intentional sampling and retention policy.
 - Schema, render, package, and Kind upgrade/rollback validation for the full
   tracing configuration contract without chart-owned collector resources.
-- Runtime v0.27.0 outbound W3C `traceparent` and optional `tracestate`
+- Runtime v0.28.0 outbound W3C `traceparent` and optional `tracestate`
   propagation through the existing tracing configuration contract.
 - Explicit runtime privacy boundaries for baggage, request IDs, arbitrary
   headers, payloads, and credentials, without chart-owned receiver resources.
+- Runtime v0.28.0 structured operational events for configuration, provider
+  readiness, lifecycle, graceful drain, and trace-export failures.
+- Default-deployment validation of safe startup events from live pod logs.
+- Explicit operational-log privacy boundaries without chart-owned collectors,
+  shippers, storage backends, dashboards, alerts, sidecars, or volumes.
 
 The immediate focus is runtime compatibility operations: automated runtime
 version proposals, an explicit compatibility matrix, release recovery

--- a/scripts/chart-smoke-test.sh
+++ b/scripts/chart-smoke-test.sh
@@ -15,6 +15,7 @@ values="$(mktemp)"
 headers="$(mktemp)"
 body="$(mktemp)"
 port_forward_log="$(mktemp)"
+runtime_log="$(mktemp)"
 created_cluster=false
 port_forward_pid=""
 
@@ -33,7 +34,7 @@ cleanup() {
         kind delete cluster --name "$cluster" >/dev/null 2>&1 || true
     fi
 
-    rm -f "$values" "$headers" "$body" "$port_forward_log"
+    rm -f "$values" "$headers" "$body" "$port_forward_log" "$runtime_log"
 }
 
 trap cleanup EXIT INT TERM
@@ -177,6 +178,13 @@ assert_equal "$request_id" "helm-smoke-1" "request correlation header"
 curl --fail --silent --show-error "http://127.0.0.1:$port/metrics" --output "$body"
 grep -q '^trussium_http_requests_active 0\.0$' "$body"
 grep -q '^process_start_time_seconds ' "$body"
+
+kubectl --context "$context" --namespace "$namespace" logs \
+    -l app.kubernetes.io/name=trussium --tail=100 >"$runtime_log"
+grep -q '"event":"runtime.configuration.loaded"' "$runtime_log"
+grep -q '"event":"provider.configuration.unavailable"' "$runtime_log"
+grep -q '"event":"observability.configuration.loaded"' "$runtime_log"
+grep -q '"event":"runtime.started"' "$runtime_log"
 
 kill "$port_forward_pid" >/dev/null 2>&1 || true
 wait "$port_forward_pid" >/dev/null 2>&1 || true

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 3
 image:
-  tag: "0.27.0"
+  tag: "0.28.0"
 autoscaling:
   enabled: false
 observability:

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -47,8 +47,20 @@ def test_chart_metadata_tracks_runtime_independently() -> None:
     assert metadata["type"] == "application"
     assert re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])
     assert metadata["version"] == project["project"]["version"]
-    assert metadata["appVersion"] == "0.27.0"
+    assert metadata["appVersion"] == "0.28.0"
     assert metadata["annotations"]["artifacthub.io/operator"] == "false"
+
+
+def test_kind_validates_runtime_v028_operational_log_contract() -> None:
+    """Compatibility CI should bind the release and live pod-log assertions."""
+    workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    smoke_script = (REPOSITORY_ROOT / "scripts" / "chart-smoke-test.sh").read_text()
+
+    assert "ref: v0.28.0" in workflow
+    assert '"event":"runtime.configuration.loaded"' in smoke_script
+    assert '"event":"provider.configuration.unavailable"' in smoke_script
+    assert '"event":"observability.configuration.loaded"' in smoke_script
+    assert '"event":"runtime.started"' in smoke_script
 
 
 def test_default_render_preserves_production_runtime_contract() -> None:
@@ -77,7 +89,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert pod_spec["securityContext"]["runAsGroup"] == 10001
     assert pod_spec["securityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
     assert pod_spec["imagePullSecrets"] == [{"name": "ghcr-credentials"}]
-    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.27.0"
+    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.28.0"
     assert container["ports"][0]["containerPort"] == 9000
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]


### PR DESCRIPTION
Closes #13

## Summary

- Update the official chart's default compatible runtime from v0.27.0 to v0.28.0.
- Advance the empty `image.tag` default, CI runtime checkout, fixtures, render assertions, and Kind source validation together.
- Validate v0.28.0 structured startup events from live Helm-managed pods.
- Document the operational event, privacy, and provider-readiness boundaries without adding chart configuration or resources.
- Preserve all existing values, JSON Schema, templates, tracing defaults, metrics, HPA, security, Secret, health, and lifecycle behavior.
- Release the backward-compatible runtime target update on the chart 0.3.2 patch line.

## Motivation

Runtime v0.28.0 adds a stable bounded JSON event contract for safe configuration summaries, provider configuration readiness, application and server lifecycle, graceful drain outcomes, invalid settings, and trace-export failures. Chart v0.3.1 still defaults to runtime v0.27.0 and checks out that tag in compatibility CI, so installations with an empty `image.tag` do not receive the released diagnostics.

Kubernetes already owns the container standard-output stream. The chart should track and validate the new runtime while avoiding a second configuration surface or ownership of collectors, shippers, storage, dashboards, alerts, and provider health probes.

## Implementation

- Verify the v0.28.0 GitHub release, wheel, source archive, and published multi-platform runtime image before editing the chart.
- Update `Chart.yaml` `appVersion` from 0.27.0 to 0.28.0 while leaving the independently managed source chart version at 0.3.1 for semantic release.
- Update the default rendered image assertion to `ghcr.io/trussiumhq/trussium:0.28.0`.
- Update the custom image-tag fixture to 0.28.0 while preserving explicit override support.
- Update GitHub Actions to check out runtime tag v0.28.0 for the real Kind lifecycle.
- Extend the Kind lifecycle to assert `runtime.configuration.loaded`, `provider.configuration.unavailable`, `observability.configuration.loaded`, and `runtime.started` in live pod logs.
- Document that provider events describe local configuration readiness rather than network availability, credential validity, or model health.
- Document the exclusion of credentials, endpoints, payloads, raw settings, rejected input, exception messages, and span data.
- Update root and chart operator guidance without changing the existing tracing contract.
- Add chart 0.3.2 to runtime 0.28.x in the compatibility matrix while retaining historical chart lines.
- Update the canonical chart roadmap to record v0.28.0 compatibility and production pod-log validation.
- Make no changes to `values.yaml`, `values.schema.json`, templates, runtime environment variables, or Kubernetes resources.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy tests`
- `uv run pytest -q` — 15 passed
- `uv lock --check`
- `scripts/helm-validate.sh`
- `scripts/chart-package.sh`
- `TRUSSIUM_RUNTIME_SOURCE=../trussium-runtime-docs scripts/chart-smoke-test.sh`
- `git diff --check`

## Manual validation

- Verified runtime release v0.28.0 includes `trussium-0.28.0-py3-none-any.whl` and `trussium-0.28.0.tar.gz`.
- Verified `ghcr.io/trussiumhq/trussium:0.28.0` as a multi-platform OCI index for Linux AMD64 and ARM64.
- Verified runtime image digest `sha256:bb28f2fe84a7684c56ea038f8190800031c59929b8e8bcafe9a8a92a6dcea1de`.
- Packaged the chart locally and confirmed metadata reports source chart version 0.3.1 before release and `appVersion` 0.28.0.
- Rendered the packaged chart and confirmed the default image is `ghcr.io/trussiumhq/trussium:0.28.0`.
- Confirmed the default ConfigMap still renders metrics enabled, tracing disabled, and no credential values.
- Confirmed the chart still renders no Secret, log collector, shipper, backend, dashboard, alert, monitoring CRD, or operator resource.
- Created a disposable Kind v1.36.1 cluster and built the released neighboring runtime v0.28.0 source.
- Installed pinned Metrics Server v0.8.1 and confirmed two ready replicas with `ScalingActive=True`.
- Confirmed health, metrics, hardened security, request correlation, and tracing-disabled defaults.
- Confirmed all four expected startup operational events in live runtime pod logs.
- Upgraded to three fixed replicas with tracing enabled and confirmed every configured trace setting exactly in the live ConfigMap.
- Rolled back and confirmed autoscaling, two ready replicas, and tracing-disabled behavior returned.
- Uninstalled the release, confirmed resource removal, and confirmed the disposable cluster was deleted.

## Compatibility

- Chart 0.3.2 defaults to runtime 0.28.x; chart 0.3.1 remains documented with runtime 0.27.x.
- Existing values, JSON Schema, and templates remain byte-for-byte unchanged.
- Existing metrics, tracing, HPA, fixed replicas, security, provider Secret, health, shutdown, upgrade, rollback, and uninstall behavior remains unchanged.
- Tracing remains disabled by default, and the existing tracing enablement, service name, sample ratio, endpoint, and timeout values remain backward compatible.
- Empty `image.tag` now selects runtime v0.28.0; explicit `image.tag` overrides remain supported with operator-owned compatibility validation.
- Missing provider configuration remains non-fatal and health and metrics endpoints remain available.
- Provider configuration events do not change readiness semantics or perform dependency probes.
- Kubernetes 1.25+, Helm 3.12+, port 9000, runtime-only ownership, and independent chart versioning remain unchanged.
- The chart still does not install `trussium-operator`.

## Privacy and ownership

- The chart does not introduce values for credentials, logging endpoints, exporter headers, log levels, or arbitrary event fields.
- Runtime operational events exclude credentials, provider and collector endpoints, payloads, raw settings, rejected values, exception messages, and span data.
- `provider.configuration.ready` and `provider.configuration.unavailable` report local runtime configuration only; they do not claim provider reachability or model availability.
- Kubernetes platform log collection, transport, storage, access control, retention, dashboards, and alerts remain operator-owned.
- No collector, shipper, sidecar, volume, backend, monitoring CRD, Secret, additional RBAC, or network surface is added.

## Risks and mitigations

- The target runtime release and both architecture manifests were verified before chart changes.
- A patch Conventional Commit reflects that the chart value and resource surface is unchanged.
- Deterministic tests bind `appVersion`, default image rendering, custom overrides, and CI runtime checkout to v0.28.0.
- The complete real Kind lifecycle validates the chart and runtime together rather than relying only on template rendering.
- Live pod-log assertions prove the released event contract reaches the platform log stream under default chart settings.
- Documentation explicitly separates provider configuration readiness from future dependency-aware readiness checks.
- Historical compatibility is retained in the matrix rather than rewriting chart v0.3.1.
- No template or schema changes means upgrade and rollback values remain stable.

## Documentation

- Root README compatibility matrix records chart 0.3.2 to runtime 0.28.x and preserves chart 0.3.1 to runtime 0.27.x.
- Root operations guidance documents structured runtime events, privacy exclusions, Kubernetes log ownership, and the provider-readiness boundary.
- Chart README adds the same operator-facing structured operational logging contract.
- Development guidance targets v0.28.0 and includes live pod-log validation in the complete Kind lifecycle.
- Canonical chart roadmap records runtime v0.28.0 compatibility, startup events, and log ownership boundaries.

## Checklist

- [x] Issue confirmed before implementation
- [x] Fresh branch created from updated main
- [x] Runtime v0.28.0 release assets and multi-platform image verified first
- [x] Default `appVersion`, image rendering, CI checkout, fixtures, and tests updated together
- [x] Existing values, schema, templates, and resources preserved unchanged
- [x] Tracing remains disabled by default
- [x] Provider configuration readiness remains separate from network health
- [x] No collector, shipper, backend, dashboard, alert, Secret, monitoring CRD, or operator resources added
- [x] Ruff, formatting, strict MyPy, Pytest, Helm lint/render, and packaging pass
- [x] Complete Kind install, HPA, operational-log, tracing upgrade, rollback, uninstall, and cleanup pass
- [x] Compatibility matrix and canonical roadmap updated completely
- [x] Conventional Commit used
