### PR TITLE
Update chart for runtime v0.29.0 portable dashboards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: trussiumhq/trussium
-          ref: v0.28.0
+          ref: v0.29.0
           path: runtime
 
       - name: Install Helm

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ future `trussium-operator`.
 - An `autoscaling/v2` HorizontalPodAutoscaler with conservative production
   behavior.
 
-No Namespace, provider credentials, registry credentials, Ingress,
-Prometheus, Prometheus Adapter, monitoring custom resources, or operator
-resources are created.
+No Namespace, provider credentials, registry credentials, Ingress, Grafana,
+Prometheus, Loki, Tempo, collector, log agent, dashboard, alert, monitoring
+custom resource, or operator resource is created.
 
 ## Prerequisites
 
@@ -68,6 +68,7 @@ The chart defaults to the compatible runtime release in `Chart.yaml`'s
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
+| `0.3.3` | `0.29.x` | `>=1.25` |
 | `0.3.2` | `0.28.x` | `>=1.25` |
 | `0.3.1` | `0.27.x` | `>=1.25` |
 | `0.3.0` | `0.26.x` | `>=1.25` |
@@ -183,7 +184,7 @@ choose sampling and retention policies appropriate to the cluster. Do not put
 collector credentials in `extraConfig`; use an organization-managed network
 or secret-based integration outside the chart.
 
-Runtime v0.28.0 propagates W3C `traceparent` and optional `tracestate` from the
+Runtime v0.29.0 propagates W3C `traceparent` and optional `tracestate` from the
 active provider span to supported OpenAI and Ollama-compatible JSON and SSE
 requests. It does not propagate baggage, request IDs, arbitrary inbound
 headers, prompts, completions, bodies, or credentials as tracing metadata. A
@@ -192,7 +193,7 @@ own span; the chart does not install or instrument that receiver. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
 for the complete span, privacy, lifecycle, sampling, and propagation contract.
 
-Runtime v0.28.0 also emits newline-delimited structured operational JSON for
+Runtime v0.29.0 also emits newline-delimited structured operational JSON for
 safe configuration summaries, provider configuration readiness, application
 and server lifecycle, graceful-drain outcomes, invalid configuration, and
 trace-export failures. Provider readiness events describe local configuration;
@@ -203,6 +204,16 @@ on the Kubernetes container log stream and does not install a collector,
 shipper, storage backend, dashboard, or alert. See the
 [runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
 for the stable event and privacy contract.
+
+Runtime v0.29.0 provides three portable Grafana dashboard JSON models in the
+runtime repository: a Prometheus overview, a Loki structured-log view, and a
+Tempo trace investigation view. Prometheus is required only for the overview;
+Loki and Tempo remain optional. The chart does not bundle, mount, import, or
+provision those files and does not install Grafana, observability backends,
+collectors, log agents, dashboard custom resources, or alerts. Operators own
+data collection, dashboard import, backend access control, and retention. See
+the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.29.0/docs/DASHBOARDS.md)
+for artifacts, import methods, variables, privacy, and troubleshooting.
 
 The complete value reference is in the
 [chart README](charts/trussium/README.md). `values.schema.json` rejects unknown
@@ -260,7 +271,7 @@ scripts/helm-validate.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.28.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.29.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
 autoscaling, runtime metrics, tracing configuration, operational startup logs,
 readiness, HTTP request correlation, fixed-scale upgrade, autoscaling rollback,

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.3.2
-appVersion: "0.28.0"
+appVersion: "0.29.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -114,7 +114,7 @@ network and secret controls. The runtime excludes health and metrics traffic
 and does not attach prompts, bodies, credentials, query strings, raw URLs, or
 exception messages to spans.
 
-With runtime v0.28.0, the active provider span is propagated to supported
+With runtime v0.29.0, the active provider span is propagated to supported
 OpenAI and Ollama-compatible JSON and SSE requests as W3C `traceparent` and
 optional `tracestate`. Baggage, request IDs, arbitrary inbound headers,
 payloads, and credentials remain behind the runtime privacy boundary. The
@@ -125,7 +125,7 @@ for the complete contract.
 
 ## Structured operational logs
 
-Runtime v0.28.0 writes bounded newline-delimited JSON events to standard
+Runtime v0.29.0 writes bounded newline-delimited JSON events to standard
 output for startup configuration, provider configuration readiness,
 observability enablement, application and server shutdown, graceful-drain
 timeouts, invalid settings, and trace-export failures.
@@ -142,3 +142,23 @@ rule, volume, sidecar, or new value for this contract. Kubernetes platform log
 collection remains operator-owned. See the
 [runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
 for the stable event table and privacy boundary.
+
+## Portable runtime dashboards
+
+Runtime v0.29.0 provides three independently importable Grafana dashboard JSON
+models in the runtime repository:
+
+- `Trussium Runtime Overview` uses Prometheus for demand, active work,
+  outcomes, latency, process health, and uptime.
+- `Trussium Runtime Logs` uses Loki for configuration, lifecycle, execution,
+  shutdown, and export events.
+- `Trussium Runtime Traces` uses Tempo for recent, failed, slow, HTTP,
+  capability, and provider trace searches.
+
+Prometheus is required only for the overview. Loki and Tempo are optional. This
+chart does not bundle, mount, import, or provision dashboard JSON and does not
+install Grafana, any observability backend, a collector, log agent, dashboard
+sidecar, custom resource, or alert. Collection, access control, retention, and
+dashboard lifecycle remain operator-owned. See the
+[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.29.0/docs/DASHBOARDS.md)
+for import, provisioning, variables, privacy, and troubleshooting.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.28.0
+The production Helm chart now carries the validated Trussium v0.29.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.
@@ -33,15 +33,21 @@ Kubernetes contract into an independently released distribution:
   with an intentional sampling and retention policy.
 - Schema, render, package, and Kind upgrade/rollback validation for the full
   tracing configuration contract without chart-owned collector resources.
-- Runtime v0.28.0 outbound W3C `traceparent` and optional `tracestate`
+- Runtime v0.29.0 outbound W3C `traceparent` and optional `tracestate`
   propagation through the existing tracing configuration contract.
 - Explicit runtime privacy boundaries for baggage, request IDs, arbitrary
   headers, payloads, and credentials, without chart-owned receiver resources.
-- Runtime v0.28.0 structured operational events for configuration, provider
+- Runtime v0.29.0 structured operational events for configuration, provider
   readiness, lifecycle, graceful drain, and trace-export failures.
 - Default-deployment validation of safe startup events from live pod logs.
 - Explicit operational-log privacy boundaries without chart-owned collectors,
   shippers, storage backends, dashboards, alerts, sidecars, or volumes.
+- Runtime v0.29.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
+  stable identities and selectable operator-owned data sources.
+- Explicit dashboard ownership boundaries without chart-bundled JSON,
+  ConfigMaps, sidecars, custom resources, monitoring backends, or alerts.
+- Version-pinned dashboard import, collection, privacy, and troubleshooting
+  guidance linked from chart operations documentation.
 
 The immediate focus is runtime compatibility operations: automated runtime
 version proposals, an explicit compatibility matrix, release recovery
@@ -73,6 +79,8 @@ runbooks, and validation across supported Kubernetes minor versions.
 
 - [x] Configurable HorizontalPodAutoscaler support after runtime metrics exist.
 - [x] Configurable OpenTelemetry runtime tracing after instrumentation exists.
+- [x] Portable runtime dashboard compatibility guidance without chart-owned
+  dashboard or backend resources.
 - Optional NetworkPolicy after supported network contracts are defined.
 - Optional ServiceMonitor after observability endpoints stabilize.
 - Optional Ingress integration without owning certificate issuance.

--- a/scripts/chart-smoke-test.sh
+++ b/scripts/chart-smoke-test.sh
@@ -119,6 +119,14 @@ kubectl --context "$context" --namespace "$namespace" rollout status deployment/
     --timeout=180s
 wait_for_autoscaling
 
+helm --kube-context "$context" get manifest "$release" --namespace "$namespace" >"$body"
+if grep -Eiq \
+    'grafana|loki|tempo|dashboard|^kind: (ServiceMonitor|PodMonitor|PrometheusRule)$' \
+    "$body"; then
+    echo "Helm release rendered an operator-owned observability resource" >&2
+    exit 1
+fi
+
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deployment trussium \
     -o jsonpath='{.status.readyReplicas}')" "2" "ready replicas after install"
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" \

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -35,4 +35,11 @@ if grep -Eq '^kind: Secret$' "$default_render" "$custom_render"; then
     exit 1
 fi
 
+if grep -Eiq \
+    'grafana|loki|tempo|dashboard|^kind: (ServiceMonitor|PodMonitor|PrometheusRule)$' \
+    "$default_render" "$custom_render"; then
+    echo "observability backends and dashboards must remain operator-owned" >&2
+    exit 1
+fi
+
 echo "Helm chart linting and rendering validation passed"

--- a/scripts/package-smoke-test.sh
+++ b/scripts/package-smoke-test.sh
@@ -20,4 +20,9 @@ helm show chart "$package" >/dev/null
 helm show values "$package" >/dev/null
 helm lint --strict "$package"
 
+if tar -tzf "$package" | grep -Eiq 'grafana|loki|tempo|dashboard'; then
+    echo "packaged chart must not bundle observability backends or dashboards" >&2
+    exit 1
+fi
+
 echo "Packaged chart validation passed for $package"

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 3
 image:
-  tag: "0.28.0"
+  tag: "0.29.0"
 autoscaling:
   enabled: false
 observability:

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -47,20 +47,25 @@ def test_chart_metadata_tracks_runtime_independently() -> None:
     assert metadata["type"] == "application"
     assert re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])
     assert metadata["version"] == project["project"]["version"]
-    assert metadata["appVersion"] == "0.28.0"
+    assert metadata["appVersion"] == "0.29.0"
     assert metadata["annotations"]["artifacthub.io/operator"] == "false"
 
 
-def test_kind_validates_runtime_v028_operational_log_contract() -> None:
-    """Compatibility CI should bind the release and live pod-log assertions."""
+def test_kind_validates_runtime_v029_observability_contract() -> None:
+    """Compatibility CI should bind the release and existing live assertions."""
     workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     smoke_script = (REPOSITORY_ROOT / "scripts" / "chart-smoke-test.sh").read_text()
+    root_readme = (REPOSITORY_ROOT / "README.md").read_text()
+    chart_readme = (CHART / "README.md").read_text()
 
-    assert "ref: v0.28.0" in workflow
+    assert "ref: v0.29.0" in workflow
     assert '"event":"runtime.configuration.loaded"' in smoke_script
     assert '"event":"provider.configuration.unavailable"' in smoke_script
     assert '"event":"observability.configuration.loaded"' in smoke_script
     assert '"event":"runtime.started"' in smoke_script
+    assert "blob/v0.29.0/docs/DASHBOARDS.md" in root_readme
+    assert "blob/v0.29.0/docs/DASHBOARDS.md" in chart_readme
+    assert 'helm --kube-context "$context" get manifest' in smoke_script
 
 
 def test_default_render_preserves_production_runtime_contract() -> None:
@@ -89,7 +94,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert pod_spec["securityContext"]["runAsGroup"] == 10001
     assert pod_spec["securityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
     assert pod_spec["imagePullSecrets"] == [{"name": "ghcr-credentials"}]
-    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.28.0"
+    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.29.0"
     assert container["ports"][0]["containerPort"] == 9000
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]
@@ -214,6 +219,24 @@ def test_chart_does_not_render_credentials() -> None:
     assert "kind: Secret" not in result.stdout
     assert "API_KEY" not in result.stdout
     assert "YOUR_GITHUB_TOKEN" not in result.stdout
+
+
+def test_chart_does_not_render_observability_backends_or_dashboards() -> None:
+    """Portable dashboard import and backend lifecycle should stay operator-owned."""
+    rendered = run_helm("template", "trussium", str(CHART)).stdout.lower()
+
+    assert "grafana" not in rendered
+    assert "loki" not in rendered
+    assert "tempo" not in rendered
+    assert "servicemonitor" not in rendered
+    assert "podmonitor" not in rendered
+    assert "prometheusrule" not in rendered
+    assert "dashboard" not in rendered
+
+    validate_script = (REPOSITORY_ROOT / "scripts" / "helm-validate.sh").read_text()
+    package_script = (REPOSITORY_ROOT / "scripts" / "package-smoke-test.sh").read_text()
+    assert "observability backends and dashboards must remain operator-owned" in validate_script
+    assert "packaged chart must not bundle observability backends or dashboards" in package_script
 
 
 def test_schema_rejects_invalid_values() -> None:


### PR DESCRIPTION
Closes #15

## Summary

- Update the official chart's default compatible runtime from v0.28.0 to v0.29.0.
- Advance the empty `image.tag` default, CI runtime checkout, fixtures, render assertions, and Kind source validation together.
- Document the released Prometheus, Loki, and Tempo dashboard artifacts and their operator-owned lifecycle.
- Add render, package, and live-release safeguards proving the chart does not bundle or install dashboards or observability backends.
- Preserve all existing values, JSON Schema, templates, tracing defaults, metrics, HPA, security, Secret, health, and lifecycle behavior.
- Release the backward-compatible runtime target update on the chart 0.3.3 patch line.

## Motivation

Runtime v0.29.0 publishes three independently importable Grafana dashboards over the existing bounded metrics, structured events, and trace hierarchy. Chart v0.3.2 still defaults to runtime v0.28.0 and checks out that tag in compatibility CI.

The dashboard models are deployment artifacts in the runtime repository, not runtime image contents or Helm resources. The chart should track the verified release and point operators to those artifacts while retaining its runtime-only ownership boundary.

## Implementation

- Verify the v0.29.0 GitHub release, wheel, source archive, and Linux AMD64/ARM64 OCI image before editing.
- Update `Chart.yaml` `appVersion` from 0.28.0 to 0.29.0 while leaving source chart version 0.3.2 for semantic release.
- Update the default rendered image, custom tag fixture, and CI runtime checkout to v0.29.0.
- Retain live startup-event assertions in the Kind lifecycle.
- Add a static contract that rendered resources contain no Grafana, Loki, Tempo, dashboards, ServiceMonitor, PodMonitor, or PrometheusRule.
- Extend render validation, packaged-chart validation, and the installed Helm manifest smoke check with the same ownership boundary.
- Document each dashboard, its backend, optionality, import ownership, access-control and retention boundary, and version-pinned runtime guide.
- Add chart 0.3.3 to runtime 0.29.x in the compatibility matrix while preserving historical lines.
- Update the canonical chart roadmap completely.
- Make no changes to values, schema, templates, runtime environment variables, or Kubernetes resources.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy tests`
- `uv run pytest -q` — 16 passed
- `uv lock --check`
- `scripts/helm-validate.sh`
- `scripts/chart-package.sh`
- `TRUSSIUM_RUNTIME_SOURCE=../trussium-runtime-docs scripts/chart-smoke-test.sh`
- `git diff --check`

## Manual validation

- Verified runtime v0.29.0 wheel and source archive on the GitHub release.
- Verified `ghcr.io/trussiumhq/trussium:0.29.0` as a Linux AMD64/ARM64 OCI index.
- Verified runtime image digest `sha256:08f9a79e5b49066efc8ff5dc3720dd144b82a05f3465a751b7a2b3cfd78fe2c7`.
- Packaged the chart locally and confirmed source chart version 0.3.2 plus `appVersion` 0.29.0.
- Rendered the package and confirmed `ghcr.io/trussiumhq/trussium:0.29.0` with no dashboard or backend resources.
- Created a disposable Kind v1.36.1 cluster and built the exact neighboring runtime v0.29.0 release source.
- Installed pinned Metrics Server v0.8.1 and confirmed two ready replicas with active autoscaling.
- Confirmed health, metrics, hardened security, request correlation, tracing-disabled defaults, and four structured startup events.
- Inspected the installed Helm manifest and confirmed no Grafana, Loki, Tempo, dashboard, or monitoring custom resource.
- Upgraded to three fixed replicas with tracing enabled and confirmed all trace settings.
- Rolled back and confirmed autoscaling, two replicas, and tracing-disabled behavior returned.
- Uninstalled the release and confirmed disposable-cluster cleanup.

## Compatibility

- Chart 0.3.3 defaults to runtime 0.29.x; chart 0.3.2 remains documented with runtime 0.28.x.
- Existing values, JSON Schema, and templates remain byte-for-byte unchanged.
- Existing metrics, tracing, HPA, fixed replicas, security, provider Secret, health, shutdown, log, upgrade, rollback, and uninstall behavior remains unchanged.
- Empty `image.tag` selects runtime v0.29.0; explicit overrides remain supported with operator-owned validation.
- Kubernetes 1.25+, Helm 3.12+, port 9000, runtime-only ownership, and independent chart versioning remain unchanged.
- The chart still does not install `trussium-operator`.

## Dashboard and ownership boundary

- The runtime overview uses Prometheus; structured logs use Loki; trace investigation uses Tempo.
- Prometheus is required only for the overview, while Loki and Tempo remain optional.
- Dashboard JSON remains in the runtime repository and outside the runtime image and chart package.
- The chart adds no values, ConfigMaps, mounts, sidecars, operators, CRDs, RBAC, or network surfaces for dashboards.
- Grafana, collectors, log agents, backends, data collection, import, access control, retention, and alerts remain operator-owned.
- Existing telemetry privacy and cardinality boundaries remain unchanged.

## Risks and mitigations

- The target release and both architecture manifests were verified before chart changes.
- Deterministic tests bind chart metadata, rendering, fixtures, CI checkout, and documentation to v0.29.0.
- Three independent checks cover rendered source, packaged contents, and live installed manifests.
- The real Kind lifecycle validates install, autoscaling, runtime behavior, upgrade, rollback, uninstall, and cleanup.
- Historical compatibility remains explicit rather than rewriting prior chart lines.
- No template or schema changes means upgrade and rollback values remain stable.

## Documentation

- Root compatibility matrix records chart 0.3.3 to runtime 0.29.x.
- Root and chart guidance describe all three dashboard artifacts and version-pin the runtime dashboard guide.
- Documentation states that the chart does not import or provision dashboards or backends.
- Canonical chart roadmap records v0.29.0 compatibility and the dashboard ownership boundary.

## Checklist

- [x] Issue confirmed before implementation
- [x] Fresh branch created from updated main
- [x] Runtime v0.29.0 release assets and multi-platform image verified first
- [x] Default `appVersion`, image rendering, CI checkout, fixtures, and tests updated together
- [x] Existing values, schema, templates, and resources preserved unchanged
- [x] No dashboard or backend artifacts bundled or rendered
- [x] Ruff, formatting, strict MyPy, Pytest, Helm lint/render, and packaging pass
- [x] Complete Kind install, HPA, boundary, logs, tracing upgrade, rollback, uninstall, and cleanup pass
- [x] Compatibility matrix and canonical roadmap updated completely
- [x] Conventional Commit used
