### PR TITLE
Update chart for runtime v0.30.0 alerting guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: trussiumhq/trussium
-          ref: v0.29.0
+          ref: v0.30.0
           path: runtime
 
       - name: Install Helm

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The chart defaults to the compatible runtime release in `Chart.yaml`'s
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
+| `0.3.4` | `0.30.x` | `>=1.25` |
 | `0.3.3` | `0.29.x` | `>=1.25` |
 | `0.3.2` | `0.28.x` | `>=1.25` |
 | `0.3.1` | `0.27.x` | `>=1.25` |
@@ -184,7 +185,7 @@ choose sampling and retention policies appropriate to the cluster. Do not put
 collector credentials in `extraConfig`; use an organization-managed network
 or secret-based integration outside the chart.
 
-Runtime v0.29.0 propagates W3C `traceparent` and optional `tracestate` from the
+Runtime v0.30.0 propagates W3C `traceparent` and optional `tracestate` from the
 active provider span to supported OpenAI and Ollama-compatible JSON and SSE
 requests. It does not propagate baggage, request IDs, arbitrary inbound
 headers, prompts, completions, bodies, or credentials as tracing metadata. A
@@ -193,7 +194,7 @@ own span; the chart does not install or instrument that receiver. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
 for the complete span, privacy, lifecycle, sampling, and propagation contract.
 
-Runtime v0.29.0 also emits newline-delimited structured operational JSON for
+Runtime v0.30.0 also emits newline-delimited structured operational JSON for
 safe configuration summaries, provider configuration readiness, application
 and server lifecycle, graceful-drain outcomes, invalid configuration, and
 trace-export failures. Provider readiness events describe local configuration;
@@ -205,15 +206,31 @@ shipper, storage backend, dashboard, or alert. See the
 [runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
 for the stable event and privacy contract.
 
-Runtime v0.29.0 provides three portable Grafana dashboard JSON models in the
+Runtime v0.30.0 provides three portable Grafana dashboard JSON models in the
 runtime repository: a Prometheus overview, a Loki structured-log view, and a
 Tempo trace investigation view. Prometheus is required only for the overview;
 Loki and Tempo remain optional. The chart does not bundle, mount, import, or
 provision those files and does not install Grafana, observability backends,
 collectors, log agents, dashboard custom resources, or alerts. Operators own
 data collection, dashboard import, backend access control, and retention. See
-the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.29.0/docs/DASHBOARDS.md)
+the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.30.0/docs/DASHBOARDS.md)
 for artifacts, import methods, variables, privacy, and troubleshooting.
+
+Runtime v0.30.0 also provides five portable Prometheus starter alerts for
+missing telemetry, elevated request failures, elevated cancellations, high p95
+latency, and process restarts. Their severity, hold times, traffic guards, and
+thresholds are reference values that operators must review against their SLOs,
+traffic, target-label topology, and maintenance model before paging.
+
+The rules remain source-repository artifacts. This chart does not bundle or
+load them and does not create a rule ConfigMap, `PrometheusRule`,
+`AlertmanagerConfig`, notification route, silence, or monitoring backend.
+Operators own rule loading, target scoping, threshold tuning, routing,
+inhibition, maintenance windows, access control, and retention. See the
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.30.0/docs/ALERTING.md)
+and the
+[reference rules](https://github.com/trussiumhq/trussium/blob/v0.30.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+for the complete contract and runbooks.
 
 The complete value reference is in the
 [chart README](charts/trussium/README.md). `values.schema.json` rejects unknown
@@ -271,7 +288,7 @@ scripts/helm-validate.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.29.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.30.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
 autoscaling, runtime metrics, tracing configuration, operational startup logs,
 readiness, HTTP request correlation, fixed-scale upgrade, autoscaling rollback,

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.3.3
-appVersion: "0.29.0"
+appVersion: "0.30.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -114,7 +114,7 @@ network and secret controls. The runtime excludes health and metrics traffic
 and does not attach prompts, bodies, credentials, query strings, raw URLs, or
 exception messages to spans.
 
-With runtime v0.29.0, the active provider span is propagated to supported
+With runtime v0.30.0, the active provider span is propagated to supported
 OpenAI and Ollama-compatible JSON and SSE requests as W3C `traceparent` and
 optional `tracestate`. Baggage, request IDs, arbitrary inbound headers,
 payloads, and credentials remain behind the runtime privacy boundary. The
@@ -125,7 +125,7 @@ for the complete contract.
 
 ## Structured operational logs
 
-Runtime v0.29.0 writes bounded newline-delimited JSON events to standard
+Runtime v0.30.0 writes bounded newline-delimited JSON events to standard
 output for startup configuration, provider configuration readiness,
 observability enablement, application and server shutdown, graceful-drain
 timeouts, invalid settings, and trace-export failures.
@@ -145,7 +145,7 @@ for the stable event table and privacy boundary.
 
 ## Portable runtime dashboards
 
-Runtime v0.29.0 provides three independently importable Grafana dashboard JSON
+Runtime v0.30.0 provides three independently importable Grafana dashboard JSON
 models in the runtime repository:
 
 - `Trussium Runtime Overview` uses Prometheus for demand, active work,
@@ -160,5 +160,23 @@ chart does not bundle, mount, import, or provision dashboard JSON and does not
 install Grafana, any observability backend, a collector, log agent, dashboard
 sidecar, custom resource, or alert. Collection, access control, retention, and
 dashboard lifecycle remain operator-owned. See the
-[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.29.0/docs/DASHBOARDS.md)
+[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.30.0/docs/DASHBOARDS.md)
 for import, provisioning, variables, privacy, and troubleshooting.
+
+## Portable runtime alerts
+
+Runtime v0.30.0 provides five portable Prometheus starter alerts for missing
+telemetry, elevated request failures, elevated cancellations, high p95 latency,
+and process restarts. The published severities, hold times, traffic guards, and
+thresholds are reference values that operators must tune for their SLOs,
+traffic, target labels, and maintenance model before paging.
+
+The rules remain source-repository artifacts. This chart does not bundle,
+mount, or load them and does not create a rule ConfigMap, `PrometheusRule`,
+`AlertmanagerConfig`, notification route, silence, or monitoring backend.
+Operators own rule loading, target scoping, threshold tuning, routing,
+inhibition, maintenance windows, access control, and retention. See the
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.30.0/docs/ALERTING.md)
+and the
+[reference rules](https://github.com/trussiumhq/trussium/blob/v0.30.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+for the complete contract and runbooks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.29.0
+The production Helm chart now carries the validated Trussium v0.30.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.
@@ -33,21 +33,28 @@ Kubernetes contract into an independently released distribution:
   with an intentional sampling and retention policy.
 - Schema, render, package, and Kind upgrade/rollback validation for the full
   tracing configuration contract without chart-owned collector resources.
-- Runtime v0.29.0 outbound W3C `traceparent` and optional `tracestate`
+- Runtime v0.30.0 outbound W3C `traceparent` and optional `tracestate`
   propagation through the existing tracing configuration contract.
 - Explicit runtime privacy boundaries for baggage, request IDs, arbitrary
   headers, payloads, and credentials, without chart-owned receiver resources.
-- Runtime v0.29.0 structured operational events for configuration, provider
+- Runtime v0.30.0 structured operational events for configuration, provider
   readiness, lifecycle, graceful drain, and trace-export failures.
 - Default-deployment validation of safe startup events from live pod logs.
 - Explicit operational-log privacy boundaries without chart-owned collectors,
   shippers, storage backends, dashboards, alerts, sidecars, or volumes.
-- Runtime v0.29.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
+- Runtime v0.30.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
   stable identities and selectable operator-owned data sources.
 - Explicit dashboard ownership boundaries without chart-bundled JSON,
   ConfigMaps, sidecars, custom resources, monitoring backends, or alerts.
 - Version-pinned dashboard import, collection, privacy, and troubleshooting
   guidance linked from chart operations documentation.
+- Runtime v0.30.0 portable Prometheus starter alerts and operator runbooks for
+  missing telemetry, request failures, cancellations, latency, and restarts.
+- Explicit alerting ownership boundaries without chart-bundled rules,
+  ConfigMaps, `PrometheusRule`, `AlertmanagerConfig`, notification routing, or
+  monitoring backends.
+- Version-pinned alert adoption, tuning, routing, lifecycle, privacy, and
+  troubleshooting guidance linked from chart operations documentation.
 
 The immediate focus is runtime compatibility operations: automated runtime
 version proposals, an explicit compatibility matrix, release recovery
@@ -81,6 +88,8 @@ runbooks, and validation across supported Kubernetes minor versions.
 - [x] Configurable OpenTelemetry runtime tracing after instrumentation exists.
 - [x] Portable runtime dashboard compatibility guidance without chart-owned
   dashboard or backend resources.
+- [x] Portable runtime alerting compatibility guidance without chart-owned
+  rules, notification routing, or backend resources.
 - Optional NetworkPolicy after supported network contracts are defined.
 - Optional ServiceMonitor after observability endpoints stabilize.
 - Optional Ingress integration without owning certificate issuance.

--- a/scripts/chart-smoke-test.sh
+++ b/scripts/chart-smoke-test.sh
@@ -121,7 +121,7 @@ wait_for_autoscaling
 
 helm --kube-context "$context" get manifest "$release" --namespace "$namespace" >"$body"
 if grep -Eiq \
-    'grafana|loki|tempo|dashboard|^kind: (ServiceMonitor|PodMonitor|PrometheusRule)$' \
+    'grafana|loki|tempo|dashboard|alertmanager|alerting|trussium-runtime-alerts|^kind: (ServiceMonitor|PodMonitor|PrometheusRule|AlertmanagerConfig)$' \
     "$body"; then
     echo "Helm release rendered an operator-owned observability resource" >&2
     exit 1

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -36,9 +36,9 @@ if grep -Eq '^kind: Secret$' "$default_render" "$custom_render"; then
 fi
 
 if grep -Eiq \
-    'grafana|loki|tempo|dashboard|^kind: (ServiceMonitor|PodMonitor|PrometheusRule)$' \
+    'grafana|loki|tempo|dashboard|alertmanager|alerting|trussium-runtime-alerts|^kind: (ServiceMonitor|PodMonitor|PrometheusRule|AlertmanagerConfig)$' \
     "$default_render" "$custom_render"; then
-    echo "observability backends and dashboards must remain operator-owned" >&2
+    echo "observability backends, dashboards, and alerts must remain operator-owned" >&2
     exit 1
 fi
 

--- a/scripts/package-smoke-test.sh
+++ b/scripts/package-smoke-test.sh
@@ -20,8 +20,8 @@ helm show chart "$package" >/dev/null
 helm show values "$package" >/dev/null
 helm lint --strict "$package"
 
-if tar -tzf "$package" | grep -Eiq 'grafana|loki|tempo|dashboard'; then
-    echo "packaged chart must not bundle observability backends or dashboards" >&2
+if tar -tzf "$package" | grep -Eiq 'grafana|loki|tempo|dashboard|alertmanager|alerting|prometheus.*rule|alert.*rule'; then
+    echo "packaged chart must not bundle observability backends, dashboards, or alerts" >&2
     exit 1
 fi
 

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 3
 image:
-  tag: "0.29.0"
+  tag: "0.30.0"
 autoscaling:
   enabled: false
 observability:

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -47,24 +47,28 @@ def test_chart_metadata_tracks_runtime_independently() -> None:
     assert metadata["type"] == "application"
     assert re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])
     assert metadata["version"] == project["project"]["version"]
-    assert metadata["appVersion"] == "0.29.0"
+    assert metadata["appVersion"] == "0.30.0"
     assert metadata["annotations"]["artifacthub.io/operator"] == "false"
 
 
-def test_kind_validates_runtime_v029_observability_contract() -> None:
+def test_kind_validates_runtime_v030_observability_contract() -> None:
     """Compatibility CI should bind the release and existing live assertions."""
     workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     smoke_script = (REPOSITORY_ROOT / "scripts" / "chart-smoke-test.sh").read_text()
     root_readme = (REPOSITORY_ROOT / "README.md").read_text()
     chart_readme = (CHART / "README.md").read_text()
 
-    assert "ref: v0.29.0" in workflow
+    assert "ref: v0.30.0" in workflow
     assert '"event":"runtime.configuration.loaded"' in smoke_script
     assert '"event":"provider.configuration.unavailable"' in smoke_script
     assert '"event":"observability.configuration.loaded"' in smoke_script
     assert '"event":"runtime.started"' in smoke_script
-    assert "blob/v0.29.0/docs/DASHBOARDS.md" in root_readme
-    assert "blob/v0.29.0/docs/DASHBOARDS.md" in chart_readme
+    assert "blob/v0.30.0/docs/DASHBOARDS.md" in root_readme
+    assert "blob/v0.30.0/docs/DASHBOARDS.md" in chart_readme
+    assert "blob/v0.30.0/docs/ALERTING.md" in root_readme
+    assert "blob/v0.30.0/docs/ALERTING.md" in chart_readme
+    assert "blob/v0.30.0/deploy/observability/prometheus/rules/" in root_readme
+    assert "blob/v0.30.0/deploy/observability/prometheus/rules/" in chart_readme
     assert 'helm --kube-context "$context" get manifest' in smoke_script
 
 
@@ -94,7 +98,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert pod_spec["securityContext"]["runAsGroup"] == 10001
     assert pod_spec["securityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
     assert pod_spec["imagePullSecrets"] == [{"name": "ghcr-credentials"}]
-    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.29.0"
+    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.30.0"
     assert container["ports"][0]["containerPort"] == 9000
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]
@@ -221,22 +225,29 @@ def test_chart_does_not_render_credentials() -> None:
     assert "YOUR_GITHUB_TOKEN" not in result.stdout
 
 
-def test_chart_does_not_render_observability_backends_or_dashboards() -> None:
-    """Portable dashboard import and backend lifecycle should stay operator-owned."""
+def test_chart_does_not_render_observability_backends_dashboards_or_alerts() -> None:
+    """Portable observability artifacts and backend lifecycle stay operator-owned."""
     rendered = run_helm("template", "trussium", str(CHART)).stdout.lower()
 
     assert "grafana" not in rendered
     assert "loki" not in rendered
     assert "tempo" not in rendered
+    assert "alertmanager" not in rendered
     assert "servicemonitor" not in rendered
     assert "podmonitor" not in rendered
     assert "prometheusrule" not in rendered
+    assert "alertmanagerconfig" not in rendered
     assert "dashboard" not in rendered
+    assert "alerting" not in rendered
 
     validate_script = (REPOSITORY_ROOT / "scripts" / "helm-validate.sh").read_text()
     package_script = (REPOSITORY_ROOT / "scripts" / "package-smoke-test.sh").read_text()
-    assert "observability backends and dashboards must remain operator-owned" in validate_script
-    assert "packaged chart must not bundle observability backends or dashboards" in package_script
+    assert "observability backends, dashboards, and alerts must remain operator-owned" in (
+        validate_script
+    )
+    assert "packaged chart must not bundle observability backends, dashboards, or alerts" in (
+        package_script
+    )
 
 
 def test_schema_rejects_invalid_values() -> None:


### PR DESCRIPTION
Closes #17

## Summary

Update the official `trussium` chart's default compatible runtime from v0.29.0 to v0.30.0 and document the portable runtime alerting contract.

The chart continues to deploy only the Trussium runtime. Alert-rule loading, notification routing, and the monitoring stack remain operator-owned.

## Motivation

Runtime v0.30.0 publishes five portable Prometheus starter alerts, executable rule tests, and complete operator runbooks for the existing bounded metrics. Chart v0.3.3 still defaults to runtime v0.29.0, so an installation using the chart default does not select the release associated with that guidance.

This update advances the verified runtime target without adding monitoring resources or expanding the chart's ownership boundary.

## Implementation

- Advance chart `appVersion` and empty-tag default rendering to runtime v0.30.0.
- Advance the CI runtime checkout and custom fixture to v0.30.0.
- Update deterministic metadata, render, and compatibility assertions.
- Add version-pinned links to the runtime alerting guide and reference-rule artifact.
- Document the five alert categories and starter-threshold tuning requirement.
- Strengthen render, package, and live-release checks against alerting infrastructure and rule artifacts.
- Update the compatibility matrix and complete Helm roadmap.
- Preserve the chart source version at v0.3.3 for semantic-release ownership.

## Runtime release evidence

- Release: https://github.com/trussiumhq/trussium/releases/tag/v0.30.0
- Python artifacts: `trussium-0.30.0-py3-none-any.whl` and `trussium-0.30.0.tar.gz`
- Image: `ghcr.io/trussiumhq/trussium:0.30.0`
- OCI index digest: `sha256:0b7709fd81db152619898d048f50234e8973e34d211c344d314bbf0a73056953`
- Platforms: `linux/amd64` and `linux/arm64`
- Release workflow and multi-platform image publication completed successfully.

## Testing

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy tests`
- `uv run pytest` — 16 passed
- `uv lock --check`
- `scripts/helm-validate.sh`
- `scripts/chart-package.sh`
- `git diff --check`

## Manual validation

- Rendered the default chart and confirmed `ghcr.io/trussiumhq/trussium:0.30.0`.
- Linted and rendered default and customized values with strict schema validation.
- Packaged and validated the source chart while keeping the independently managed source version at v0.3.3.
- Built runtime v0.30.0 from its released source in a temporary Kind v1.36.1 cluster.
- Installed pinned Metrics Server v0.8.1 and confirmed two ready replicas with active CPU autoscaling.
- Confirmed runtime health, metrics, request correlation, safe operational startup events, security settings, and disruption protection.
- Confirmed the live Helm manifest contains no operator-owned observability or alerting resources.
- Exercised fixed-scale and tracing configuration upgrade, autoscaling rollback, and uninstall.
- Confirmed temporary cluster cleanup completed.

## Compatibility

- Empty `image.tag` now selects runtime v0.30.0.
- Explicit image-tag overrides remain supported and operator-validated.
- Existing values, JSON Schema, templates, and Kubernetes resource kinds are unchanged.
- Metrics, tracing, dashboards, HPA, fixed replicas, provider Secret references, health probes, shutdown behavior, security controls, upgrade, rollback, and uninstall remain compatible.
- Tracing remains disabled by default.
- This backward-compatible runtime target update will release as chart patch v0.3.4.

## Alerting ownership boundary

Runtime v0.30.0 supplies source-repository starter rules and runbooks. The chart does not bundle, mount, or load those rules and does not create a rule ConfigMap, `PrometheusRule`, `AlertmanagerConfig`, ServiceMonitor, PodMonitor, notification route, silence, Grafana resource, monitoring backend, or operator resource.

Operators own rule loading, target scoping, threshold tuning, notification routing, inhibition, maintenance windows, monitoring infrastructure, access control, retention, and escalation policy. All published thresholds remain reference values that must be reviewed before paging.

## Privacy and cardinality

- The reference alerts use the runtime's existing bounded metric dimensions and Prometheus target labels.
- The chart adds no alert labels, telemetry dimensions, payload capture, Secret data, or observability credentials.
- Request identifiers, execution identifiers, paths, prompts, payloads, exception messages, endpoints, and provider responses remain outside notification labels.
- Existing logs, traces, and dashboards remain the operator-controlled diagnostic pivots.

## Risks and mitigations

- Runtime/chart drift is prevented by pinning v0.30.0 in CI, metadata assertions, default rendering, documentation, and live Kind validation.
- Accidental chart ownership of alerting infrastructure is guarded by unit, render, package, and live-release checks.
- Starter thresholds may not match every environment; both READMEs explicitly require operator tuning.
- Existing custom image tags are unaffected, with compatibility responsibility remaining explicit.
- No values, templates, workload settings, or Kubernetes resource kinds change.

## Documentation

- Update the root compatibility matrix for chart v0.3.4 and runtime v0.30.x.
- Version-pin the dashboard guide to v0.30.0.
- Add version-pinned alerting guide and reference-rule links.
- Document the five alert categories, tuning requirement, and ownership boundary in both READMEs.
- Update the Helm roadmap with delivered portable alerting compatibility.

## Checklist

- [x] Runtime v0.30.0 release artifacts verified
- [x] Linux AMD64/ARM64 runtime image verified
- [x] Default runtime advanced to v0.30.0
- [x] CI and Kind source advanced to v0.30.0
- [x] Existing chart values, schema, templates, and resources preserved
- [x] Custom image override preserved
- [x] Alerting guide and rule source version-pinned
- [x] No chart-owned rules, alert routing, backends, CRDs, or operator resources
- [x] Static, render, package, and live lifecycle validation completed
- [x] Compatibility matrix and roadmap updated
