### PR TITLE
Add runtime v0.31.0 dependency readiness configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: trussiumhq/trussium
-          ref: v0.30.0
+          ref: v0.31.0
           path: runtime
 
       - name: Install Helm

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The chart defaults to the compatible runtime release in `Chart.yaml`'s
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
+| `0.4.0` | `0.31.x` | `>=1.25` |
 | `0.3.4` | `0.30.x` | `>=1.25` |
 | `0.3.3` | `0.29.x` | `>=1.25` |
 | `0.3.2` | `0.28.x` | `>=1.25` |
@@ -120,6 +121,45 @@ providerSecret:
 Set `providerSecret.name` to an empty string when no provider Secret should be
 referenced. The chart never accepts or renders credential values.
 
+## Dependency-aware readiness
+
+Runtime v0.31.0 can make `/health/ready` reflect provider metadata access and,
+optionally, the availability of a required model. The chart keeps these checks
+disabled by default so installs without provider configuration retain the
+existing `{"status":"ok"}` readiness response.
+
+Enable the checks only after the referenced provider Secret and provider
+endpoint are available:
+
+```yaml
+readiness:
+  dependencyChecksEnabled: true
+  dependencyTimeoutSeconds: 1
+  dependencyCacheSeconds: 10
+  requiredModel: gpt-4.1-mini
+```
+
+An empty `requiredModel` checks the provider's model-list metadata endpoint;
+a non-empty value checks that exact model without performing inference. The
+timeout bounds an individual provider check. Both successful and failed
+results are cached for the configured window, and concurrent probes share one
+in-flight check.
+
+The `readiness` group controls runtime dependency policy. The separate
+`readinessProbe` group controls Kubernetes probe timing and thresholds. Keep
+the Kubernetes probe timeout long enough for the runtime dependency timeout,
+allow for the configured failure threshold during provider incidents, and use
+a staged rollout before enabling checks in production.
+
+The chart renders only non-secret readiness settings. A required model is
+visible to anyone who can read the ConfigMap, so do not put credentials,
+provider endpoints, or other secrets in these values. The chart never creates
+provider credentials, installs a provider or model server, downloads models,
+or performs inference. See the version-pinned
+[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/HEALTH.md)
+for response reasons, rollout guidance, privacy boundaries, and
+troubleshooting.
+
 ## Configure
 
 Inspect every default and its documentation:
@@ -151,6 +191,12 @@ resources:
 timeouts:
   providerRequestSeconds: 90
   streamIdleSeconds: 45
+
+readiness:
+  dependencyChecksEnabled: true
+  dependencyTimeoutSeconds: 1
+  dependencyCacheSeconds: 10
+  requiredModel: gpt-4.1-mini
 
 observability:
   tracing:
@@ -185,7 +231,7 @@ choose sampling and retention policies appropriate to the cluster. Do not put
 collector credentials in `extraConfig`; use an organization-managed network
 or secret-based integration outside the chart.
 
-Runtime v0.30.0 propagates W3C `traceparent` and optional `tracestate` from the
+Runtime v0.31.0 propagates W3C `traceparent` and optional `tracestate` from the
 active provider span to supported OpenAI and Ollama-compatible JSON and SSE
 requests. It does not propagate baggage, request IDs, arbitrary inbound
 headers, prompts, completions, bodies, or credentials as tracing metadata. A
@@ -194,11 +240,12 @@ own span; the chart does not install or instrument that receiver. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
 for the complete span, privacy, lifecycle, sampling, and propagation contract.
 
-Runtime v0.30.0 also emits newline-delimited structured operational JSON for
+Runtime v0.31.0 also emits newline-delimited structured operational JSON for
 safe configuration summaries, provider configuration readiness, application
 and server lifecycle, graceful-drain outcomes, invalid configuration, and
-trace-export failures. Provider readiness events describe local configuration;
-they do not probe provider connectivity or change `/health/ready` semantics.
+trace-export failures. Provider configuration events describe local setup;
+dependency readiness events separately describe the optional provider metadata
+check and only affect `/health/ready` when checks are enabled.
 The runtime excludes credentials, endpoints, payloads, raw settings, rejected
 values, exception messages, and span data from these events. The chart relies
 on the Kubernetes container log stream and does not install a collector,
@@ -206,17 +253,17 @@ shipper, storage backend, dashboard, or alert. See the
 [runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
 for the stable event and privacy contract.
 
-Runtime v0.30.0 provides three portable Grafana dashboard JSON models in the
+Runtime v0.31.0 provides three portable Grafana dashboard JSON models in the
 runtime repository: a Prometheus overview, a Loki structured-log view, and a
 Tempo trace investigation view. Prometheus is required only for the overview;
 Loki and Tempo remain optional. The chart does not bundle, mount, import, or
 provision those files and does not install Grafana, observability backends,
 collectors, log agents, dashboard custom resources, or alerts. Operators own
 data collection, dashboard import, backend access control, and retention. See
-the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.30.0/docs/DASHBOARDS.md)
+the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/DASHBOARDS.md)
 for artifacts, import methods, variables, privacy, and troubleshooting.
 
-Runtime v0.30.0 also provides five portable Prometheus starter alerts for
+Runtime v0.31.0 also provides five portable Prometheus starter alerts for
 missing telemetry, elevated request failures, elevated cancellations, high p95
 latency, and process restarts. Their severity, hold times, traffic guards, and
 thresholds are reference values that operators must review against their SLOs,
@@ -227,9 +274,9 @@ load them and does not create a rule ConfigMap, `PrometheusRule`,
 `AlertmanagerConfig`, notification route, silence, or monitoring backend.
 Operators own rule loading, target scoping, threshold tuning, routing,
 inhibition, maintenance windows, access control, and retention. See the
-[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.30.0/docs/ALERTING.md)
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/ALERTING.md)
 and the
-[reference rules](https://github.com/trussiumhq/trussium/blob/v0.30.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+[reference rules](https://github.com/trussiumhq/trussium/blob/v0.31.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
 for the complete contract and runbooks.
 
 The complete value reference is in the
@@ -288,11 +335,12 @@ scripts/helm-validate.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.30.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.31.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
 autoscaling, runtime metrics, tracing configuration, operational startup logs,
-readiness, HTTP request correlation, fixed-scale upgrade, autoscaling rollback,
-and uninstall:
+default dependency readiness, readiness configuration upgrade and rollback,
+HTTP request correlation, fixed-scale upgrade, autoscaling rollback, and
+uninstall:
 
 ```bash
 TRUSSIUM_RUNTIME_SOURCE=../trussium scripts/chart-smoke-test.sh

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.3.4
-appVersion: "0.30.0"
+appVersion: "0.31.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -33,6 +33,10 @@ default compatible runtime image.
 | `runtime.gracefulShutdownSeconds` | `30` | Active-workload drain deadline. |
 | `timeouts.providerRequestSeconds` | `60` | Provider request deadline. |
 | `timeouts.streamIdleSeconds` | `30` | Streaming event idle deadline. |
+| `readiness.dependencyChecksEnabled` | `false` | Include provider metadata access in runtime readiness. |
+| `readiness.dependencyTimeoutSeconds` | `1` | Positive deadline for one dependency check. |
+| `readiness.dependencyCacheSeconds` | `10` | Positive success and failure cache window. |
+| `readiness.requiredModel` | `""` | Exact model to require; empty lists provider models. |
 | `observability.metrics.enabled` | `true` | Expose runtime metrics at `/metrics`. |
 | `observability.tracing.enabled` | `false` | Enable runtime OpenTelemetry tracing and OTLP export. |
 | `observability.tracing.serviceName` | `trussium` | OpenTelemetry `service.name`. |
@@ -86,6 +90,41 @@ Runtime metrics remain independently configurable through
 `observability.metrics.enabled`. The chart does not install Prometheus,
 Prometheus Adapter, ServiceMonitor, or other monitoring resources.
 
+## Dependency-aware readiness
+
+Runtime v0.31.0 can include provider metadata access in `/health/ready`. The
+chart preserves backward-compatible behavior by disabling dependency checks by
+default:
+
+```yaml
+readiness:
+  dependencyChecksEnabled: true
+  dependencyTimeoutSeconds: 1
+  dependencyCacheSeconds: 10
+  requiredModel: gpt-4.1-mini
+```
+
+When `requiredModel` is empty, the runtime lists provider models as a metadata
+check. When it is non-empty, the runtime retrieves that exact model. Neither
+path performs inference. The timeout bounds each check; successful and failed
+results use the same cache window, and concurrent probes share one check.
+
+The `readiness` group configures runtime dependency policy. `readinessProbe`
+independently configures Kubernetes probe timing and failure thresholds. The
+three base settings are always rendered in the non-secret ConfigMap;
+`TRUSSIUM_READINESS__REQUIRED_MODEL` is omitted when no model is configured.
+
+Before enabling checks, supply a valid existing provider Secret, verify network
+access from runtime pods, and stage the rollout. The chart does not create
+credentials, install providers or model servers, download models, or own
+provider availability. The required-model identifier is non-secret ConfigMap
+data visible to anyone who can read that resource; do not place credentials,
+provider endpoints, or other secrets in readiness values. See the
+version-pinned
+[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/HEALTH.md)
+for response reasons, rollout guidance, privacy boundaries, and
+troubleshooting.
+
 ## OpenTelemetry tracing
 
 Tracing remains disabled by default because the chart does not install an
@@ -114,7 +153,7 @@ network and secret controls. The runtime excludes health and metrics traffic
 and does not attach prompts, bodies, credentials, query strings, raw URLs, or
 exception messages to spans.
 
-With runtime v0.30.0, the active provider span is propagated to supported
+With runtime v0.31.0, the active provider span is propagated to supported
 OpenAI and Ollama-compatible JSON and SSE requests as W3C `traceparent` and
 optional `tracestate`. Baggage, request IDs, arbitrary inbound headers,
 payloads, and credentials remain behind the runtime privacy boundary. The
@@ -125,15 +164,16 @@ for the complete contract.
 
 ## Structured operational logs
 
-Runtime v0.30.0 writes bounded newline-delimited JSON events to standard
+Runtime v0.31.0 writes bounded newline-delimited JSON events to standard
 output for startup configuration, provider configuration readiness,
 observability enablement, application and server shutdown, graceful-drain
 timeouts, invalid settings, and trace-export failures.
 
 `provider.configuration.ready` and `provider.configuration.unavailable`
 describe whether the runtime constructed a provider capability from local
-configuration. They do not probe network reachability, authenticate a
-credential, inspect a model, or alter the readiness endpoint.
+configuration. Separate `readiness.configuration.loaded` and dependency
+transition events describe the optional metadata check without exposing raw
+provider failures.
 
 Operational events exclude credentials, provider and collector endpoints,
 payloads, raw settings, rejected values, exception messages, and span data.
@@ -145,7 +185,7 @@ for the stable event table and privacy boundary.
 
 ## Portable runtime dashboards
 
-Runtime v0.30.0 provides three independently importable Grafana dashboard JSON
+Runtime v0.31.0 provides three independently importable Grafana dashboard JSON
 models in the runtime repository:
 
 - `Trussium Runtime Overview` uses Prometheus for demand, active work,
@@ -160,12 +200,12 @@ chart does not bundle, mount, import, or provision dashboard JSON and does not
 install Grafana, any observability backend, a collector, log agent, dashboard
 sidecar, custom resource, or alert. Collection, access control, retention, and
 dashboard lifecycle remain operator-owned. See the
-[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.30.0/docs/DASHBOARDS.md)
+[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/DASHBOARDS.md)
 for import, provisioning, variables, privacy, and troubleshooting.
 
 ## Portable runtime alerts
 
-Runtime v0.30.0 provides five portable Prometheus starter alerts for missing
+Runtime v0.31.0 provides five portable Prometheus starter alerts for missing
 telemetry, elevated request failures, elevated cancellations, high p95 latency,
 and process restarts. The published severities, hold times, traffic guards, and
 thresholds are reference values that operators must tune for their SLOs,
@@ -176,7 +216,7 @@ mount, or load them and does not create a rule ConfigMap, `PrometheusRule`,
 `AlertmanagerConfig`, notification route, silence, or monitoring backend.
 Operators own rule loading, target scoping, threshold tuning, routing,
 inhibition, maintenance windows, access control, and retention. See the
-[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.30.0/docs/ALERTING.md)
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/ALERTING.md)
 and the
-[reference rules](https://github.com/trussiumhq/trussium/blob/v0.30.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+[reference rules](https://github.com/trussiumhq/trussium/blob/v0.31.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
 for the complete contract and runbooks.

--- a/charts/trussium/templates/NOTES.txt
+++ b/charts/trussium/templates/NOTES.txt
@@ -20,5 +20,16 @@ OpenTelemetry trace export is enabled for service {{ .Values.observability.traci
 Confirm that the runtime network can reach {{ .Values.observability.tracing.otlpTracesEndpoint }}.
 This chart does not install an OpenTelemetry Collector or tracing backend.
 {{- end }}
+{{- if .Values.readiness.dependencyChecksEnabled }}
+
+Provider dependency readiness checks are enabled.
+Confirm that the existing provider Secret and provider endpoint are available before rollout.
+{{- if .Values.readiness.requiredModel }}
+An exact required-model metadata check is configured; the model identifier is not printed here.
+{{- else }}
+Readiness will use the provider model-list metadata endpoint.
+{{- end }}
+This chart does not create provider credentials, providers, model servers, or model artifacts.
+{{- end }}
 
 This chart installs the Trussium runtime only. It does not install trussium-operator.

--- a/charts/trussium/templates/configmap.yaml
+++ b/charts/trussium/templates/configmap.yaml
@@ -11,6 +11,12 @@ data:
   TRUSSIUM_RUNTIME__GRACEFUL_SHUTDOWN_SECONDS: {{ .Values.runtime.gracefulShutdownSeconds | quote }}
   TRUSSIUM_TIMEOUTS__PROVIDER_REQUEST_SECONDS: {{ .Values.timeouts.providerRequestSeconds | quote }}
   TRUSSIUM_TIMEOUTS__STREAM_IDLE_SECONDS: {{ .Values.timeouts.streamIdleSeconds | quote }}
+  TRUSSIUM_READINESS__DEPENDENCY_CHECKS_ENABLED: {{ .Values.readiness.dependencyChecksEnabled | quote }}
+  TRUSSIUM_READINESS__DEPENDENCY_TIMEOUT_SECONDS: {{ .Values.readiness.dependencyTimeoutSeconds | quote }}
+  TRUSSIUM_READINESS__DEPENDENCY_CACHE_SECONDS: {{ .Values.readiness.dependencyCacheSeconds | quote }}
+  {{- if .Values.readiness.requiredModel }}
+  TRUSSIUM_READINESS__REQUIRED_MODEL: {{ .Values.readiness.requiredModel | quote }}
+  {{- end }}
   TRUSSIUM_OBSERVABILITY__METRICS_ENABLED: {{ .Values.observability.metrics.enabled | quote }}
   TRUSSIUM_OBSERVABILITY__TRACING_ENABLED: {{ .Values.observability.tracing.enabled | quote }}
   TRUSSIUM_OBSERVABILITY__TRACING_SERVICE_NAME: {{ .Values.observability.tracing.serviceName | quote }}

--- a/charts/trussium/values.schema.json
+++ b/charts/trussium/values.schema.json
@@ -14,6 +14,7 @@
     "service",
     "runtime",
     "timeouts",
+    "readiness",
     "observability",
     "autoscaling",
     "providerSecret",
@@ -93,6 +94,22 @@
       "properties": {
         "providerRequestSeconds": {"type": "integer", "minimum": 1},
         "streamIdleSeconds": {"type": "integer", "minimum": 1}
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dependencyChecksEnabled",
+        "dependencyTimeoutSeconds",
+        "dependencyCacheSeconds",
+        "requiredModel"
+      ],
+      "properties": {
+        "dependencyChecksEnabled": {"type": "boolean"},
+        "dependencyTimeoutSeconds": {"type": "number", "exclusiveMinimum": 0},
+        "dependencyCacheSeconds": {"type": "number", "exclusiveMinimum": 0},
+        "requiredModel": {"type": "string", "pattern": "^$|.*\\S.*"}
       }
     },
     "observability": {

--- a/charts/trussium/values.yaml
+++ b/charts/trussium/values.yaml
@@ -49,6 +49,12 @@ timeouts:
   providerRequestSeconds: 60
   streamIdleSeconds: 30
 
+readiness:
+  dependencyChecksEnabled: false
+  dependencyTimeoutSeconds: 1
+  dependencyCacheSeconds: 10
+  requiredModel: ""
+
 observability:
   metrics:
     enabled: true

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.30.0
+The production Helm chart now carries the validated Trussium v0.31.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.
@@ -33,28 +33,34 @@ Kubernetes contract into an independently released distribution:
   with an intentional sampling and retention policy.
 - Schema, render, package, and Kind upgrade/rollback validation for the full
   tracing configuration contract without chart-owned collector resources.
-- Runtime v0.30.0 outbound W3C `traceparent` and optional `tracestate`
+- Runtime v0.31.0 outbound W3C `traceparent` and optional `tracestate`
   propagation through the existing tracing configuration contract.
 - Explicit runtime privacy boundaries for baggage, request IDs, arbitrary
   headers, payloads, and credentials, without chart-owned receiver resources.
-- Runtime v0.30.0 structured operational events for configuration, provider
+- Runtime v0.31.0 structured operational events for configuration, provider
   readiness, lifecycle, graceful drain, and trace-export failures.
 - Default-deployment validation of safe startup events from live pod logs.
 - Explicit operational-log privacy boundaries without chart-owned collectors,
   shippers, storage backends, dashboards, alerts, sidecars, or volumes.
-- Runtime v0.30.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
+- Runtime v0.31.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
   stable identities and selectable operator-owned data sources.
 - Explicit dashboard ownership boundaries without chart-bundled JSON,
   ConfigMaps, sidecars, custom resources, monitoring backends, or alerts.
 - Version-pinned dashboard import, collection, privacy, and troubleshooting
   guidance linked from chart operations documentation.
-- Runtime v0.30.0 portable Prometheus starter alerts and operator runbooks for
+- Runtime v0.31.0 portable Prometheus starter alerts and operator runbooks for
   missing telemetry, request failures, cancellations, latency, and restarts.
 - Explicit alerting ownership boundaries without chart-bundled rules,
   ConfigMaps, `PrometheusRule`, `AlertmanagerConfig`, notification routing, or
   monitoring backends.
 - Version-pinned alert adoption, tuning, routing, lifecycle, privacy, and
   troubleshooting guidance linked from chart operations documentation.
+- Runtime v0.31.0 dependency-aware readiness settings for opt-in provider
+  metadata and required-model checks, with bounded timeout and cache controls.
+- Backward-compatible disabled defaults, conditional required-model rendering,
+  strict value validation, and live install/upgrade/rollback coverage.
+- Version-pinned health, rollout, privacy, ownership, and troubleshooting
+  guidance without chart-managed credentials, providers, or model servers.
 
 The immediate focus is runtime compatibility operations: automated runtime
 version proposals, an explicit compatibility matrix, release recovery

--- a/scripts/chart-smoke-test.sh
+++ b/scripts/chart-smoke-test.sh
@@ -153,6 +153,20 @@ assert_equal "$(kubectl --context "$context" --namespace "$namespace" get config
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
     -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__TRACING_SERVICE_NAME}')" \
     "trussium" "default tracing service name"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_READINESS__DEPENDENCY_CHECKS_ENABLED}')" \
+    "false" "default dependency readiness enablement"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_READINESS__DEPENDENCY_TIMEOUT_SECONDS}')" \
+    "1" "default dependency readiness timeout"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_READINESS__DEPENDENCY_CACHE_SECONDS}')" \
+    "10" "default dependency readiness cache"
+if kubectl --context "$context" --namespace "$namespace" get configmap trussium -o json | \
+    grep -q 'TRUSSIUM_READINESS__REQUIRED_MODEL'; then
+    echo "default ConfigMap unexpectedly rendered a required readiness model" >&2
+    exit 1
+fi
 
 port="$(python3 -c 'import socket; sock = socket.socket(); sock.bind(("127.0.0.1", 0)); print(sock.getsockname()[1]); sock.close()')"
 kubectl --context "$context" --namespace "$namespace" port-forward service/trussium \
@@ -192,6 +206,8 @@ kubectl --context "$context" --namespace "$namespace" logs \
 grep -q '"event":"runtime.configuration.loaded"' "$runtime_log"
 grep -q '"event":"provider.configuration.unavailable"' "$runtime_log"
 grep -q '"event":"observability.configuration.loaded"' "$runtime_log"
+grep -q '"event":"readiness.configuration.loaded"' "$runtime_log"
+grep -q '"dependency_checks_enabled":false' "$runtime_log"
 grep -q '"event":"runtime.started"' "$runtime_log"
 
 kill "$port_forward_pid" >/dev/null 2>&1 || true
@@ -204,7 +220,10 @@ helm --kube-context "$context" upgrade "$release" "$repository_root/charts/truss
     --set observability.tracing.serviceName=trussium-upgraded \
     --set-json observability.tracing.sampleRatio=0.25 \
     --set-string observability.tracing.otlpTracesEndpoint=http://collector.example:4318/v1/traces \
-    --set-json observability.tracing.otlpExportTimeoutSeconds=2.5 --wait --timeout 180s
+    --set-json observability.tracing.otlpExportTimeoutSeconds=2.5 \
+    --set-json readiness.dependencyTimeoutSeconds=0.75 \
+    --set-json readiness.dependencyCacheSeconds=3.5 \
+    --set-string readiness.requiredModel=required-model --wait --timeout 180s
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deployment trussium \
     -o jsonpath='{.status.readyReplicas}')" "3" "ready replicas after upgrade"
 if kubectl --context "$context" --namespace "$namespace" \
@@ -227,6 +246,18 @@ assert_equal "$(kubectl --context "$context" --namespace "$namespace" get config
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
     -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__OTLP_EXPORT_TIMEOUT_SECONDS}')" \
     "2.5" "upgraded OTLP export timeout"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_READINESS__DEPENDENCY_CHECKS_ENABLED}')" \
+    "false" "upgraded dependency readiness enablement"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_READINESS__DEPENDENCY_TIMEOUT_SECONDS}')" \
+    "0.75" "upgraded dependency readiness timeout"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_READINESS__DEPENDENCY_CACHE_SECONDS}')" \
+    "3.5" "upgraded dependency readiness cache"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_READINESS__REQUIRED_MODEL}')" \
+    "required-model" "upgraded required readiness model"
 
 helm --kube-context "$context" rollback "$release" 1 --namespace "$namespace" --wait --timeout 180s
 wait_for_autoscaling
@@ -235,6 +266,14 @@ assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deploy
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
     -o jsonpath='{.data.TRUSSIUM_OBSERVABILITY__TRACING_ENABLED}')" \
     "false" "tracing enablement after rollback"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_READINESS__DEPENDENCY_TIMEOUT_SECONDS}')" \
+    "1" "dependency readiness timeout after rollback"
+if kubectl --context "$context" --namespace "$namespace" get configmap trussium -o json | \
+    grep -q 'TRUSSIUM_READINESS__REQUIRED_MODEL'; then
+    echo "rollback ConfigMap retained the required readiness model" >&2
+    exit 1
+fi
 
 helm --kube-context "$context" uninstall "$release" --namespace "$namespace" --wait
 if kubectl --context "$context" --namespace "$namespace" get deployment trussium >/dev/null 2>&1; then

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,8 +1,13 @@
 replicaCount: 3
 image:
-  tag: "0.30.0"
+  tag: "0.31.0"
 autoscaling:
   enabled: false
+readiness:
+  dependencyChecksEnabled: true
+  dependencyTimeoutSeconds: 0.75
+  dependencyCacheSeconds: 3.5
+  requiredModel: required-model
 observability:
   metrics:
     enabled: false

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -47,29 +47,35 @@ def test_chart_metadata_tracks_runtime_independently() -> None:
     assert metadata["type"] == "application"
     assert re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])
     assert metadata["version"] == project["project"]["version"]
-    assert metadata["appVersion"] == "0.30.0"
+    assert metadata["appVersion"] == "0.31.0"
     assert metadata["annotations"]["artifacthub.io/operator"] == "false"
 
 
-def test_kind_validates_runtime_v030_observability_contract() -> None:
+def test_kind_validates_runtime_v031_readiness_contract() -> None:
     """Compatibility CI should bind the release and existing live assertions."""
     workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     smoke_script = (REPOSITORY_ROOT / "scripts" / "chart-smoke-test.sh").read_text()
     root_readme = (REPOSITORY_ROOT / "README.md").read_text()
     chart_readme = (CHART / "README.md").read_text()
 
-    assert "ref: v0.30.0" in workflow
+    assert "ref: v0.31.0" in workflow
     assert '"event":"runtime.configuration.loaded"' in smoke_script
     assert '"event":"provider.configuration.unavailable"' in smoke_script
     assert '"event":"observability.configuration.loaded"' in smoke_script
     assert '"event":"runtime.started"' in smoke_script
-    assert "blob/v0.30.0/docs/DASHBOARDS.md" in root_readme
-    assert "blob/v0.30.0/docs/DASHBOARDS.md" in chart_readme
-    assert "blob/v0.30.0/docs/ALERTING.md" in root_readme
-    assert "blob/v0.30.0/docs/ALERTING.md" in chart_readme
-    assert "blob/v0.30.0/deploy/observability/prometheus/rules/" in root_readme
-    assert "blob/v0.30.0/deploy/observability/prometheus/rules/" in chart_readme
+    assert '"event":"readiness.configuration.loaded"' in smoke_script
+    assert "blob/v0.31.0/docs/HEALTH.md" in root_readme
+    assert "blob/v0.31.0/docs/HEALTH.md" in chart_readme
+    assert "blob/v0.31.0/docs/DASHBOARDS.md" in root_readme
+    assert "blob/v0.31.0/docs/DASHBOARDS.md" in chart_readme
+    assert "blob/v0.31.0/docs/ALERTING.md" in root_readme
+    assert "blob/v0.31.0/docs/ALERTING.md" in chart_readme
+    assert "blob/v0.31.0/deploy/observability/prometheus/rules/" in root_readme
+    assert "blob/v0.31.0/deploy/observability/prometheus/rules/" in chart_readme
     assert 'helm --kube-context "$context" get manifest' in smoke_script
+    notes = (CHART / "templates" / "NOTES.txt").read_text()
+    assert "Provider dependency readiness checks are enabled" in notes
+    assert "model identifier is not printed here" in notes
 
 
 def test_default_render_preserves_production_runtime_contract() -> None:
@@ -98,7 +104,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert pod_spec["securityContext"]["runAsGroup"] == 10001
     assert pod_spec["securityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
     assert pod_spec["imagePullSecrets"] == [{"name": "ghcr-credentials"}]
-    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.30.0"
+    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.31.0"
     assert container["ports"][0]["containerPort"] == 9000
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]
@@ -127,6 +133,10 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert budget["spec"]["maxUnavailable"] == 1
 
     config_map = resource(documents, "ConfigMap")
+    assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_CHECKS_ENABLED"] == "false"
+    assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_TIMEOUT_SECONDS"] == "1"
+    assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_CACHE_SECONDS"] == "10"
+    assert "TRUSSIUM_READINESS__REQUIRED_MODEL" not in config_map["data"]
     assert config_map["data"]["TRUSSIUM_OBSERVABILITY__METRICS_ENABLED"] == "true"
     assert config_map["data"]["TRUSSIUM_OBSERVABILITY__TRACING_ENABLED"] == "false"
     assert config_map["data"]["TRUSSIUM_OBSERVABILITY__TRACING_SERVICE_NAME"] == "trussium"
@@ -206,6 +216,10 @@ def test_custom_values_render_supported_integrations() -> None:
     assert service["metadata"]["annotations"]["example.com/service"] == "custom"
 
     config_map = resource(documents, "ConfigMap")
+    assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_CHECKS_ENABLED"] == "true"
+    assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_TIMEOUT_SECONDS"] == "0.75"
+    assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_CACHE_SECONDS"] == "3.5"
+    assert config_map["data"]["TRUSSIUM_READINESS__REQUIRED_MODEL"] == "required-model"
     assert config_map["data"]["TRUSSIUM_OBSERVABILITY__METRICS_ENABLED"] == "false"
     assert config_map["data"]["TRUSSIUM_OBSERVABILITY__TRACING_ENABLED"] == "true"
     assert config_map["data"]["TRUSSIUM_OBSERVABILITY__TRACING_SERVICE_NAME"] == "trussium-custom"
@@ -299,6 +313,47 @@ def test_schema_rejects_unknown_observability_values() -> None:
     assert result.returncode != 0
     assert "unexpected" in result.stderr
     assert "Additional property" in result.stderr
+
+
+def test_schema_rejects_unknown_readiness_values() -> None:
+    result = run_helm(
+        "template",
+        "trussium",
+        str(CHART),
+        "--set",
+        "readiness.unexpected=true",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "unexpected" in result.stderr
+    assert "Additional property" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("flag", "setting", "value"),
+    [
+        ("--set", "dependencyTimeoutSeconds", "0"),
+        ("--set", "dependencyCacheSeconds", "0"),
+        ("--set-string", "requiredModel", "   "),
+    ],
+)
+def test_schema_rejects_invalid_readiness_values(
+    flag: str,
+    setting: str,
+    value: str,
+) -> None:
+    result = run_helm(
+        "template",
+        "trussium",
+        str(CHART),
+        flag,
+        f"readiness.{setting}={value}",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert setting in result.stderr
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #19

## Summary

Update the official `trussium` chart's default compatible runtime from v0.30.0 to v0.31.0 and add schema-validated configuration for the runtime's optional dependency-aware readiness checks.

The chart continues to deploy only the Trussium runtime. Dependency checks remain disabled by default, provider credentials and infrastructure remain operator-owned, and no Kubernetes resource kinds are added.

## Motivation

Runtime v0.31.0 can make `/health/ready` reflect provider metadata access and an optional required model. Chart v0.3.4 still defaults to runtime v0.30.0 and offers no typed values for this contract, forcing operators to bypass the chart's schema through `extraConfig`.

This update advances the verified runtime target and makes the readiness policy intentional, documented, and validated while preserving the existing safe behavior for installations without provider configuration.

## Implementation

- Advance chart `appVersion` and empty-tag default rendering to runtime v0.31.0.
- Advance the CI runtime checkout and custom fixture to v0.31.0.
- Add a required `readiness` values group with disabled checks, a 1-second dependency timeout, a 10-second cache, and an empty required model by default.
- Add strict JSON Schema validation with unknown-field rejection, positive timeout/cache constraints, and empty-or-nonblank model validation.
- Always render the enablement, timeout, and cache settings into the non-secret ConfigMap.
- Render `TRUSSIUM_READINESS__REQUIRED_MODEL` only when an exact model is configured.
- Keep runtime dependency policy separate from Kubernetes `readinessProbe` timing and thresholds.
- Extend deterministic render, invalid-value, install-note, and compatibility assertions.
- Extend the Kind lifecycle test across default configuration, live logs, upgrade, rollback, and cleanup.
- Update both READMEs, the compatibility matrix, and the complete Helm roadmap.
- Preserve the chart source version at v0.3.4 for semantic-release ownership.

## Runtime release evidence

- Release: https://github.com/trussiumhq/trussium/releases/tag/v0.31.0
- Python artifacts: `trussium-0.31.0-py3-none-any.whl` and `trussium-0.31.0.tar.gz`
- Image: `ghcr.io/trussiumhq/trussium:0.31.0`
- OCI index digest: `sha256:72ad6000a831f6d9fe1708da428abb6458d7105f06ec0445eb89fb5c115b2bbe`
- Platforms: `linux/amd64` and `linux/arm64`
- Release workflow and multi-platform image publication completed successfully.

## Testing

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy tests`
- `uv run pytest` — 20 passed
- `uv lock --check`
- `scripts/helm-validate.sh`
- `scripts/chart-package.sh`
- `git diff --check`

## Manual validation

- Rendered the default chart and confirmed `ghcr.io/trussiumhq/trussium:0.31.0`.
- Confirmed dependency checks render disabled with timeout `1`, cache `10`, and no required-model environment variable.
- Rendered customized readiness values and confirmed exact boolean, decimal timeout/cache, and model output.
- Confirmed zero timeout/cache values, whitespace-only models, and unknown readiness fields fail schema validation.
- Linted and rendered default and customized values and validated the packaged chart.
- Built runtime v0.31.0 from its released source in a temporary Kind v1.36.1 cluster.
- Installed pinned Metrics Server v0.8.1 and confirmed two ready replicas with active CPU autoscaling.
- Confirmed the exact default `{"status":"ok"}` readiness response and the disabled dependency-readiness startup event.
- Confirmed runtime health, metrics, request correlation, security settings, disruption protection, and existing structured startup events.
- Upgraded to custom timeout/cache/model settings while keeping checks disabled for the provider-free smoke environment.
- Confirmed the live ConfigMap values, fixed-scale rollout, rollback to default readiness settings, HPA recovery, and uninstall.
- Confirmed temporary cluster cleanup completed.

## Compatibility

- Empty `image.tag` now selects runtime v0.31.0.
- Explicit image-tag overrides remain supported and operator-validated.
- Dependency checks remain disabled by default, preserving the existing readiness response and optional provider Secret behavior.
- The existing `readinessProbe` values and HTTP probe remain unchanged.
- Existing metrics, tracing, dashboards, alerts, HPA, fixed replicas, security, Secret, shutdown, request correlation, upgrade, rollback, and uninstall contracts remain compatible.
- No Kubernetes resource kinds, credentials, volumes, mounts, sidecars, RBAC, CRDs, providers, models, or monitoring resources are added.
- The new user-facing chart values make this a feature release and will advance the chart from v0.3.4 to v0.4.0.

## Dependency readiness contract

- Disabled checks return the existing lightweight readiness response without constructing a provider client.
- Enabled checks use provider metadata only: model listing when no model is configured or exact model retrieval when one is configured.
- The runtime performs no inference during readiness.
- The dependency timeout bounds each check, success and failure share the cache window, and concurrent probes share one in-flight check.
- Provider authentication, permission, rate-limit, timeout, reachability, model, and unexpected failures remain normalized by the runtime's bounded response contract.
- The chart configures the policy but does not own provider or model availability.

## Ownership and privacy

- Provider and registry Secrets remain external resources and are never accepted as chart values or rendered by the chart.
- The required model is non-secret ConfigMap data visible to principals that can read the ConfigMap; documentation warns against placing credentials or endpoints in readiness values.
- Install notes do not print the configured model identifier.
- Runtime readiness responses and logs exclude raw provider errors, credentials, endpoints, and model identifiers.
- The chart does not install providers, model servers, model artifacts, monitoring backends, collectors, dashboards, alerts, or `trussium-operator`.

## Risks and mitigations

- Enabling dependency checks before provider configuration can make pods unready; defaults remain disabled and both READMEs require staged rollout and network/Secret verification.
- A dependency timeout longer than the Kubernetes probe timeout can cause probe-level cancellation; documentation distinguishes both controls and directs operators to size them together.
- Provider incidents can remove pods from service; cache and failure-threshold guidance make the behavior explicit and configurable.
- Runtime/chart drift is prevented by pinning v0.31.0 in CI, metadata assertions, default rendering, version-pinned documentation, and live Kind validation.
- Accidental disclosure is limited by conditional model rendering, non-secret visibility guidance, and install notes that report only whether an exact model check is configured.

## Documentation

- Add complete dependency-readiness configuration, rollout, timeout/cache, probe, ownership, privacy, and troubleshooting guidance to both READMEs.
- Add a version-pinned runtime v0.31.0 health-guide link.
- Advance current tracing, operational logging, dashboard, alerting, and lifecycle references to runtime v0.31.0.
- Add chart v0.4.0/runtime v0.31.x to the compatibility matrix while retaining historical rows.
- Apply the identified stale-version correction throughout current chart guidance.
- Update the Helm roadmap with the delivered dependency-readiness configuration and validation contract.

## Checklist

- [x] Runtime v0.31.0 release artifacts verified
- [x] Linux AMD64/ARM64 runtime image verified
- [x] Default runtime advanced to v0.31.0
- [x] CI and Kind source advanced to v0.31.0
- [x] Typed readiness values and strict schema added
- [x] Safe disabled defaults preserved
- [x] Conditional required-model rendering verified
- [x] Kubernetes readiness-probe contract preserved
- [x] Existing provider Secret and custom image override behavior preserved
- [x] No chart-owned credentials, providers, models, monitoring resources, CRDs, or operator resources
- [x] Static, render, package, and live lifecycle validation completed
- [x] Compatibility matrix, READMEs, install notes, and roadmap updated
