### PR TITLE
Update chart for runtime v0.32.0 exception hierarchy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: trussiumhq/trussium
-          ref: v0.31.0
+          ref: v0.32.0
           path: runtime
 
       - name: Install Helm

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The chart defaults to the compatible runtime release in `Chart.yaml`'s
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
+| `0.4.1` | `0.32.x` | `>=1.25` |
 | `0.4.0` | `0.31.x` | `>=1.25` |
 | `0.3.4` | `0.30.x` | `>=1.25` |
 | `0.3.3` | `0.29.x` | `>=1.25` |
@@ -123,7 +124,7 @@ referenced. The chart never accepts or renders credential values.
 
 ## Dependency-aware readiness
 
-Runtime v0.31.0 can make `/health/ready` reflect provider metadata access and,
+Runtime v0.32.0 can make `/health/ready` reflect provider metadata access and,
 optionally, the availability of a required model. The chart keeps these checks
 disabled by default so installs without provider configuration retain the
 existing `{"status":"ok"}` readiness response.
@@ -156,7 +157,7 @@ visible to anyone who can read the ConfigMap, so do not put credentials,
 provider endpoints, or other secrets in these values. The chart never creates
 provider credentials, installs a provider or model server, downloads models,
 or performs inference. See the version-pinned
-[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/HEALTH.md)
+[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.32.0/docs/HEALTH.md)
 for response reasons, rollout guidance, privacy boundaries, and
 troubleshooting.
 
@@ -231,7 +232,7 @@ choose sampling and retention policies appropriate to the cluster. Do not put
 collector credentials in `extraConfig`; use an organization-managed network
 or secret-based integration outside the chart.
 
-Runtime v0.31.0 propagates W3C `traceparent` and optional `tracestate` from the
+Runtime v0.32.0 propagates W3C `traceparent` and optional `tracestate` from the
 active provider span to supported OpenAI and Ollama-compatible JSON and SSE
 requests. It does not propagate baggage, request IDs, arbitrary inbound
 headers, prompts, completions, bodies, or credentials as tracing metadata. A
@@ -240,7 +241,7 @@ own span; the chart does not install or instrument that receiver. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
 for the complete span, privacy, lifecycle, sampling, and propagation contract.
 
-Runtime v0.31.0 also emits newline-delimited structured operational JSON for
+Runtime v0.32.0 also emits newline-delimited structured operational JSON for
 safe configuration summaries, provider configuration readiness, application
 and server lifecycle, graceful-drain outcomes, invalid configuration, and
 trace-export failures. Provider configuration events describe local setup;
@@ -253,17 +254,24 @@ shipper, storage backend, dashboard, or alert. See the
 [runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
 for the stable event and privacy contract.
 
-Runtime v0.31.0 provides three portable Grafana dashboard JSON models in the
+Runtime v0.32.0 adds a public typed hierarchy for Trussium-owned
+configuration, lifecycle, dependency, capability, and provider failures. This
+is an additive application API: it does not change the chart, runtime settings,
+HTTP or SSE error envelopes, cancellation, or Kubernetes behavior. See the
+[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.32.0/docs/ERRORS.md)
+for stable codes, catch boundaries, compatibility, and privacy rules.
+
+Runtime v0.32.0 provides three portable Grafana dashboard JSON models in the
 runtime repository: a Prometheus overview, a Loki structured-log view, and a
 Tempo trace investigation view. Prometheus is required only for the overview;
 Loki and Tempo remain optional. The chart does not bundle, mount, import, or
 provision those files and does not install Grafana, observability backends,
 collectors, log agents, dashboard custom resources, or alerts. Operators own
 data collection, dashboard import, backend access control, and retention. See
-the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/DASHBOARDS.md)
+the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.32.0/docs/DASHBOARDS.md)
 for artifacts, import methods, variables, privacy, and troubleshooting.
 
-Runtime v0.31.0 also provides five portable Prometheus starter alerts for
+Runtime v0.32.0 also provides five portable Prometheus starter alerts for
 missing telemetry, elevated request failures, elevated cancellations, high p95
 latency, and process restarts. Their severity, hold times, traffic guards, and
 thresholds are reference values that operators must review against their SLOs,
@@ -274,9 +282,9 @@ load them and does not create a rule ConfigMap, `PrometheusRule`,
 `AlertmanagerConfig`, notification route, silence, or monitoring backend.
 Operators own rule loading, target scoping, threshold tuning, routing,
 inhibition, maintenance windows, access control, and retention. See the
-[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/ALERTING.md)
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.32.0/docs/ALERTING.md)
 and the
-[reference rules](https://github.com/trussiumhq/trussium/blob/v0.31.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+[reference rules](https://github.com/trussiumhq/trussium/blob/v0.32.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
 for the complete contract and runbooks.
 
 The complete value reference is in the
@@ -335,7 +343,7 @@ scripts/helm-validate.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.31.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.32.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
 autoscaling, runtime metrics, tracing configuration, operational startup logs,
 default dependency readiness, readiness configuration upgrade and rollback,

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.4.0
-appVersion: "0.31.0"
+appVersion: "0.32.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -92,7 +92,7 @@ Prometheus Adapter, ServiceMonitor, or other monitoring resources.
 
 ## Dependency-aware readiness
 
-Runtime v0.31.0 can include provider metadata access in `/health/ready`. The
+Runtime v0.32.0 can include provider metadata access in `/health/ready`. The
 chart preserves backward-compatible behavior by disabling dependency checks by
 default:
 
@@ -121,7 +121,7 @@ provider availability. The required-model identifier is non-secret ConfigMap
 data visible to anyone who can read that resource; do not place credentials,
 provider endpoints, or other secrets in readiness values. See the
 version-pinned
-[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/HEALTH.md)
+[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.32.0/docs/HEALTH.md)
 for response reasons, rollout guidance, privacy boundaries, and
 troubleshooting.
 
@@ -153,7 +153,7 @@ network and secret controls. The runtime excludes health and metrics traffic
 and does not attach prompts, bodies, credentials, query strings, raw URLs, or
 exception messages to spans.
 
-With runtime v0.31.0, the active provider span is propagated to supported
+With runtime v0.32.0, the active provider span is propagated to supported
 OpenAI and Ollama-compatible JSON and SSE requests as W3C `traceparent` and
 optional `tracestate`. Baggage, request IDs, arbitrary inbound headers,
 payloads, and credentials remain behind the runtime privacy boundary. The
@@ -164,7 +164,7 @@ for the complete contract.
 
 ## Structured operational logs
 
-Runtime v0.31.0 writes bounded newline-delimited JSON events to standard
+Runtime v0.32.0 writes bounded newline-delimited JSON events to standard
 output for startup configuration, provider configuration readiness,
 observability enablement, application and server shutdown, graceful-drain
 timeouts, invalid settings, and trace-export failures.
@@ -183,9 +183,18 @@ collection remains operator-owned. See the
 [runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
 for the stable event table and privacy boundary.
 
+## Runtime exception hierarchy
+
+Runtime v0.32.0 adds public typed bases for Trussium-owned configuration,
+lifecycle, dependency, capability, and provider failures. This additive Python
+API changes no chart values, templates, HTTP or SSE envelopes, cancellation,
+or Kubernetes resources. See the version-pinned
+[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.32.0/docs/ERRORS.md)
+for stable codes, catch boundaries, compatibility, and privacy rules.
+
 ## Portable runtime dashboards
 
-Runtime v0.31.0 provides three independently importable Grafana dashboard JSON
+Runtime v0.32.0 provides three independently importable Grafana dashboard JSON
 models in the runtime repository:
 
 - `Trussium Runtime Overview` uses Prometheus for demand, active work,
@@ -200,12 +209,12 @@ chart does not bundle, mount, import, or provision dashboard JSON and does not
 install Grafana, any observability backend, a collector, log agent, dashboard
 sidecar, custom resource, or alert. Collection, access control, retention, and
 dashboard lifecycle remain operator-owned. See the
-[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/DASHBOARDS.md)
+[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.32.0/docs/DASHBOARDS.md)
 for import, provisioning, variables, privacy, and troubleshooting.
 
 ## Portable runtime alerts
 
-Runtime v0.31.0 provides five portable Prometheus starter alerts for missing
+Runtime v0.32.0 provides five portable Prometheus starter alerts for missing
 telemetry, elevated request failures, elevated cancellations, high p95 latency,
 and process restarts. The published severities, hold times, traffic guards, and
 thresholds are reference values that operators must tune for their SLOs,
@@ -216,7 +225,7 @@ mount, or load them and does not create a rule ConfigMap, `PrometheusRule`,
 `AlertmanagerConfig`, notification route, silence, or monitoring backend.
 Operators own rule loading, target scoping, threshold tuning, routing,
 inhibition, maintenance windows, access control, and retention. See the
-[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.31.0/docs/ALERTING.md)
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.32.0/docs/ALERTING.md)
 and the
-[reference rules](https://github.com/trussiumhq/trussium/blob/v0.31.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+[reference rules](https://github.com/trussiumhq/trussium/blob/v0.32.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
 for the complete contract and runbooks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.31.0
+The production Helm chart now carries the validated Trussium v0.32.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.
@@ -33,34 +33,36 @@ Kubernetes contract into an independently released distribution:
   with an intentional sampling and retention policy.
 - Schema, render, package, and Kind upgrade/rollback validation for the full
   tracing configuration contract without chart-owned collector resources.
-- Runtime v0.31.0 outbound W3C `traceparent` and optional `tracestate`
+- Runtime v0.32.0 outbound W3C `traceparent` and optional `tracestate`
   propagation through the existing tracing configuration contract.
 - Explicit runtime privacy boundaries for baggage, request IDs, arbitrary
   headers, payloads, and credentials, without chart-owned receiver resources.
-- Runtime v0.31.0 structured operational events for configuration, provider
+- Runtime v0.32.0 structured operational events for configuration, provider
   readiness, lifecycle, graceful drain, and trace-export failures.
 - Default-deployment validation of safe startup events from live pod logs.
 - Explicit operational-log privacy boundaries without chart-owned collectors,
   shippers, storage backends, dashboards, alerts, sidecars, or volumes.
-- Runtime v0.31.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
+- Runtime v0.32.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
   stable identities and selectable operator-owned data sources.
 - Explicit dashboard ownership boundaries without chart-bundled JSON,
   ConfigMaps, sidecars, custom resources, monitoring backends, or alerts.
 - Version-pinned dashboard import, collection, privacy, and troubleshooting
   guidance linked from chart operations documentation.
-- Runtime v0.31.0 portable Prometheus starter alerts and operator runbooks for
+- Runtime v0.32.0 portable Prometheus starter alerts and operator runbooks for
   missing telemetry, request failures, cancellations, latency, and restarts.
 - Explicit alerting ownership boundaries without chart-bundled rules,
   ConfigMaps, `PrometheusRule`, `AlertmanagerConfig`, notification routing, or
   monitoring backends.
 - Version-pinned alert adoption, tuning, routing, lifecycle, privacy, and
   troubleshooting guidance linked from chart operations documentation.
-- Runtime v0.31.0 dependency-aware readiness settings for opt-in provider
+- Runtime v0.32.0 dependency-aware readiness settings for opt-in provider
   metadata and required-model checks, with bounded timeout and cache controls.
 - Backward-compatible disabled defaults, conditional required-model rendering,
   strict value validation, and live install/upgrade/rollback coverage.
 - Version-pinned health, rollout, privacy, ownership, and troubleshooting
   guidance without chart-managed credentials, providers, or model servers.
+- Runtime v0.32.0 public exception hierarchy compatibility guidance without new
+  chart values, templates, resources, or deployment behavior.
 
 The immediate focus is runtime compatibility operations: automated runtime
 version proposals, an explicit compatibility matrix, release recovery

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 3
 image:
-  tag: "0.31.0"
+  tag: "0.32.0"
 autoscaling:
   enabled: false
 readiness:

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -47,31 +47,33 @@ def test_chart_metadata_tracks_runtime_independently() -> None:
     assert metadata["type"] == "application"
     assert re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])
     assert metadata["version"] == project["project"]["version"]
-    assert metadata["appVersion"] == "0.31.0"
+    assert metadata["appVersion"] == "0.32.0"
     assert metadata["annotations"]["artifacthub.io/operator"] == "false"
 
 
-def test_kind_validates_runtime_v031_readiness_contract() -> None:
+def test_kind_validates_runtime_v032_exception_contract() -> None:
     """Compatibility CI should bind the release and existing live assertions."""
     workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     smoke_script = (REPOSITORY_ROOT / "scripts" / "chart-smoke-test.sh").read_text()
     root_readme = (REPOSITORY_ROOT / "README.md").read_text()
     chart_readme = (CHART / "README.md").read_text()
 
-    assert "ref: v0.31.0" in workflow
+    assert "ref: v0.32.0" in workflow
     assert '"event":"runtime.configuration.loaded"' in smoke_script
     assert '"event":"provider.configuration.unavailable"' in smoke_script
     assert '"event":"observability.configuration.loaded"' in smoke_script
     assert '"event":"runtime.started"' in smoke_script
     assert '"event":"readiness.configuration.loaded"' in smoke_script
-    assert "blob/v0.31.0/docs/HEALTH.md" in root_readme
-    assert "blob/v0.31.0/docs/HEALTH.md" in chart_readme
-    assert "blob/v0.31.0/docs/DASHBOARDS.md" in root_readme
-    assert "blob/v0.31.0/docs/DASHBOARDS.md" in chart_readme
-    assert "blob/v0.31.0/docs/ALERTING.md" in root_readme
-    assert "blob/v0.31.0/docs/ALERTING.md" in chart_readme
-    assert "blob/v0.31.0/deploy/observability/prometheus/rules/" in root_readme
-    assert "blob/v0.31.0/deploy/observability/prometheus/rules/" in chart_readme
+    assert "blob/v0.32.0/docs/ERRORS.md" in root_readme
+    assert "blob/v0.32.0/docs/ERRORS.md" in chart_readme
+    assert "blob/v0.32.0/docs/HEALTH.md" in root_readme
+    assert "blob/v0.32.0/docs/HEALTH.md" in chart_readme
+    assert "blob/v0.32.0/docs/DASHBOARDS.md" in root_readme
+    assert "blob/v0.32.0/docs/DASHBOARDS.md" in chart_readme
+    assert "blob/v0.32.0/docs/ALERTING.md" in root_readme
+    assert "blob/v0.32.0/docs/ALERTING.md" in chart_readme
+    assert "blob/v0.32.0/deploy/observability/prometheus/rules/" in root_readme
+    assert "blob/v0.32.0/deploy/observability/prometheus/rules/" in chart_readme
     assert 'helm --kube-context "$context" get manifest' in smoke_script
     notes = (CHART / "templates" / "NOTES.txt").read_text()
     assert "Provider dependency readiness checks are enabled" in notes
@@ -104,7 +106,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert pod_spec["securityContext"]["runAsGroup"] == 10001
     assert pod_spec["securityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
     assert pod_spec["imagePullSecrets"] == [{"name": "ghcr-credentials"}]
-    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.31.0"
+    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.32.0"
     assert container["ports"][0]["containerPort"] == 9000
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]


### PR DESCRIPTION
Closes #21

## Summary

Update the official `trussium` chart's default compatible runtime from v0.31.0 to v0.32.0 and document the additive public runtime exception hierarchy.

## Implementation

- Advance chart `appVersion`, empty-tag rendering, CI runtime checkout, fixture, and tests to v0.32.0.
- Add chart v0.4.1/runtime v0.32.x to the compatibility matrix.
- Version-pin health, exception, dashboard, alerting, and rule documentation to v0.32.0.
- Document that the exception hierarchy changes no chart settings, error envelopes, cancellation, or Kubernetes behavior.
- Update the Helm roadmap while preserving the source version at v0.4.0 for semantic release.

## Release evidence

- Runtime release: https://github.com/trussiumhq/trussium/releases/tag/v0.32.0
- Image: `ghcr.io/trussiumhq/trussium:0.32.0`
- OCI digest: `sha256:94050500e81efffa1a9f21c8a36204861e8ce3ebbde08011b05701f8df138bf0`
- Platforms: `linux/amd64` and `linux/arm64`

## Testing

- Ruff and formatting passed.
- Strict MyPy passed.
- Pytest: 20 passed.
- Helm lint/render and package validation passed.
- Complete Kind v1.36.1 lifecycle passed against runtime v0.32.0: install, health, autoscaling, upgrade, rollback, uninstall, and cleanup.

## Compatibility

- Empty `image.tag` now selects runtime v0.32.0.
- Custom image tags remain supported.
- Existing values, schema, templates, Kubernetes resources, readiness, tracing, metrics, HPA, security, Secret, and lifecycle behavior are unchanged.
- This compatibility-only fix will release as chart v0.4.1.

## Checklist

- [x] Runtime artifacts and multi-platform image verified
- [x] Default runtime and CI pin advanced to v0.32.0
- [x] Existing deployment contract preserved
- [x] Version-pinned exception documentation added
- [x] Static, package, and live Kind validation passed
- [x] Compatibility matrix and roadmap updated
