### PR TITLE
Update chart for runtime v0.36.0 core capability registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: trussiumhq/trussium
-          ref: v0.35.0
+          ref: v0.36.0
           path: runtime
 
       - name: Install Helm

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The chart defaults to the compatible runtime release in `Chart.yaml`'s
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
+| `0.4.5` | `0.36.x` | `>=1.25` |
 | `0.4.4` | `0.35.x` | `>=1.25` |
 | `0.4.3` | `0.34.x` | `>=1.25` |
 | `0.4.2` | `0.33.x` | `>=1.25` |
@@ -127,7 +128,7 @@ referenced. The chart never accepts or renders credential values.
 
 ## Dependency-aware readiness
 
-Runtime v0.35.0 can make `/health/ready` reflect provider metadata access and,
+Runtime v0.36.0 can make `/health/ready` reflect provider metadata access and,
 optionally, the availability of a required model. The chart keeps these checks
 disabled by default so installs without provider configuration retain the
 existing `{"status":"ok"}` readiness response.
@@ -160,7 +161,7 @@ visible to anyone who can read the ConfigMap, so do not put credentials,
 provider endpoints, or other secrets in these values. The chart never creates
 provider credentials, installs a provider or model server, downloads models,
 or performs inference. See the version-pinned
-[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/HEALTH.md)
+[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/HEALTH.md)
 for response reasons, rollout guidance, privacy boundaries, and
 troubleshooting.
 
@@ -235,7 +236,7 @@ choose sampling and retention policies appropriate to the cluster. Do not put
 collector credentials in `extraConfig`; use an organization-managed network
 or secret-based integration outside the chart.
 
-Runtime v0.35.0 propagates W3C `traceparent` and optional `tracestate` from the
+Runtime v0.36.0 propagates W3C `traceparent` and optional `tracestate` from the
 active provider span to supported OpenAI and Ollama-compatible JSON and SSE
 requests. It does not propagate baggage, request IDs, arbitrary inbound
 headers, prompts, completions, bodies, or credentials as tracing metadata. A
@@ -244,7 +245,7 @@ own span; the chart does not install or instrument that receiver. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
 for the complete span, privacy, lifecycle, sampling, and propagation contract.
 
-Runtime v0.35.0 also emits newline-delimited structured operational JSON for
+Runtime v0.36.0 also emits newline-delimited structured operational JSON for
 safe configuration summaries, provider configuration readiness, application
 and server lifecycle, graceful-drain outcomes, invalid configuration, and
 trace-export failures. Provider configuration events describe local setup;
@@ -257,34 +258,34 @@ shipper, storage backend, dashboard, or alert. See the
 [runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
 for the stable event and privacy contract.
 
-Runtime v0.35.0 adds a public typed hierarchy for Trussium-owned
+Runtime v0.36.0 adds a public typed hierarchy for Trussium-owned
 configuration, lifecycle, dependency, capability, and provider failures. This
 is an additive application API: it does not change the chart, runtime settings,
 HTTP or SSE error envelopes, cancellation, or Kubernetes behavior. See the
-[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/ERRORS.md)
+[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/ERRORS.md)
 for stable codes, catch boundaries, compatibility, and privacy rules.
 
-Runtime v0.35.0 adds a typed asynchronous lifecycle contract for
+Runtime v0.36.0 adds a typed asynchronous lifecycle contract for
 application-scoped runtime services with declaration-order startup,
 reverse-order shutdown, partial-startup rollback, and bounded per-hook cleanup.
 This is a runtime composition API: the chart does not declare services or
 hooks, add a lifecycle value, or change pod termination behavior. Operators can
 still pass advanced runtime environment settings through the existing
 `extraConfig` map after their own compatibility review. See the version-pinned
-[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/LIFECYCLE.md)
+[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/LIFECYCLE.md)
 for ordering, failure, cancellation, privacy, and extension boundaries.
 
-Runtime v0.35.0 provides a public application-scoped service registry with
+Runtime v0.36.0 provides a public application-scoped service registry with
 explicit insertion-ordered registration, stable optional and required lookup,
 immutable discovery snapshots, duplicate protection, and one-way sealing
 before lifecycle composition. This remains a runtime application API: the
 chart does not declare or discover services, add registry values, load
 plugins, or change lifecycle and pod behavior.
 See the version-pinned
-[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/SERVICE_REGISTRY.md)
+[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/SERVICE_REGISTRY.md)
 for registration, lookup, errors, ownership, privacy, and extension boundaries.
 
-Runtime v0.35.0 lets registered application services opt into bounded component
+Runtime v0.36.0 lets registered application services opt into bounded component
 health reporting. The runtime evaluates checks concurrently under independent
 deadlines, preserves registry order, normalizes failures to stable reason
 codes, emits transition-only structured events, and exposes the informational
@@ -298,20 +299,33 @@ define component checks, health policy, recovery actions, service declarations,
 or a dedicated component-health value. Advanced runtime compositions can pass
 the bounded runtime timeout through the existing `extraConfig` map after their
 own compatibility review. See the version-pinned
-[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/COMPONENT_HEALTH.md)
+[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/COMPONENT_HEALTH.md)
 for status, aggregation, deadline, event, privacy, and extension contracts.
 
-Runtime v0.35.0 provides three portable Grafana dashboard JSON models in the
+Runtime v0.36.0 adds a provider-neutral application-scoped capability registry
+with canonical names, explicit insertion-ordered registration, stable lookup,
+immutable discovery snapshots, duplicate protection, safe errors, one-way
+sealing, and application-owned execution composition. This is an additive
+runtime Python API. The chart does not declare capabilities, add registry or
+discovery values, expose an endpoint, load plugins, or change Kubernetes
+resources, probes, settings, or provider behavior. The production runtime
+registers configured chat execution internally under `chat.completions`. See
+the version-pinned
+[runtime capability registry guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/CAPABILITY_REGISTRY.md)
+for identity, registration, lookup, sealing, ownership, compatibility, error,
+privacy, and extension boundaries.
+
+Runtime v0.36.0 provides three portable Grafana dashboard JSON models in the
 runtime repository: a Prometheus overview, a Loki structured-log view, and a
 Tempo trace investigation view. Prometheus is required only for the overview;
 Loki and Tempo remain optional. The chart does not bundle, mount, import, or
 provision those files and does not install Grafana, observability backends,
 collectors, log agents, dashboard custom resources, or alerts. Operators own
 data collection, dashboard import, backend access control, and retention. See
-the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/DASHBOARDS.md)
+the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/DASHBOARDS.md)
 for artifacts, import methods, variables, privacy, and troubleshooting.
 
-Runtime v0.35.0 also provides five portable Prometheus starter alerts for
+Runtime v0.36.0 also provides five portable Prometheus starter alerts for
 missing telemetry, elevated request failures, elevated cancellations, high p95
 latency, and process restarts. Their severity, hold times, traffic guards, and
 thresholds are reference values that operators must review against their SLOs,
@@ -322,9 +336,9 @@ load them and does not create a rule ConfigMap, `PrometheusRule`,
 `AlertmanagerConfig`, notification route, silence, or monitoring backend.
 Operators own rule loading, target scoping, threshold tuning, routing,
 inhibition, maintenance windows, access control, and retention. See the
-[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/ALERTING.md)
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/ALERTING.md)
 and the
-[reference rules](https://github.com/trussiumhq/trussium/blob/v0.35.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+[reference rules](https://github.com/trussiumhq/trussium/blob/v0.36.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
 for the complete contract and runbooks.
 
 The complete value reference is in the
@@ -383,7 +397,7 @@ scripts/helm-validate.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.35.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.36.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
 autoscaling, runtime metrics, tracing configuration, operational startup logs,
 default component health and dependency readiness, readiness configuration

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.4.4
-appVersion: "0.35.0"
+appVersion: "0.36.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -92,7 +92,7 @@ Prometheus Adapter, ServiceMonitor, or other monitoring resources.
 
 ## Dependency-aware readiness
 
-Runtime v0.35.0 can include provider metadata access in `/health/ready`. The
+Runtime v0.36.0 can include provider metadata access in `/health/ready`. The
 chart preserves backward-compatible behavior by disabling dependency checks by
 default:
 
@@ -121,7 +121,7 @@ provider availability. The required-model identifier is non-secret ConfigMap
 data visible to anyone who can read that resource; do not place credentials,
 provider endpoints, or other secrets in readiness values. See the
 version-pinned
-[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/HEALTH.md)
+[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/HEALTH.md)
 for response reasons, rollout guidance, privacy boundaries, and
 troubleshooting.
 
@@ -153,7 +153,7 @@ network and secret controls. The runtime excludes health and metrics traffic
 and does not attach prompts, bodies, credentials, query strings, raw URLs, or
 exception messages to spans.
 
-With runtime v0.35.0, the active provider span is propagated to supported
+With runtime v0.36.0, the active provider span is propagated to supported
 OpenAI and Ollama-compatible JSON and SSE requests as W3C `traceparent` and
 optional `tracestate`. Baggage, request IDs, arbitrary inbound headers,
 payloads, and credentials remain behind the runtime privacy boundary. The
@@ -164,7 +164,7 @@ for the complete contract.
 
 ## Structured operational logs
 
-Runtime v0.35.0 writes bounded newline-delimited JSON events to standard
+Runtime v0.36.0 writes bounded newline-delimited JSON events to standard
 output for startup configuration, provider configuration readiness,
 observability enablement, application and server shutdown, graceful-drain
 timeouts, invalid settings, and trace-export failures.
@@ -185,16 +185,16 @@ for the stable event table and privacy boundary.
 
 ## Runtime exception hierarchy
 
-Runtime v0.35.0 adds public typed bases for Trussium-owned configuration,
+Runtime v0.36.0 adds public typed bases for Trussium-owned configuration,
 lifecycle, dependency, capability, and provider failures. This additive Python
 API changes no chart values, templates, HTTP or SSE envelopes, cancellation,
 or Kubernetes resources. See the version-pinned
-[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/ERRORS.md)
+[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/ERRORS.md)
 for stable codes, catch boundaries, compatibility, and privacy rules.
 
 ## Runtime service lifecycle
 
-Runtime v0.35.0 adds a typed asynchronous lifecycle contract for
+Runtime v0.36.0 adds a typed asynchronous lifecycle contract for
 application-scoped runtime services with declaration-order startup,
 reverse-order shutdown, partial-startup rollback, and bounded per-hook cleanup.
 This is runtime-owned composition behavior. The chart does not declare
@@ -202,24 +202,24 @@ services or hooks, add a dedicated cleanup value, or change pod termination
 behavior. Operators may pass advanced runtime environment settings through the
 existing `extraConfig` map after their own compatibility review. See the
 version-pinned
-[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/LIFECYCLE.md)
+[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/LIFECYCLE.md)
 for ordering, failure, cancellation, privacy, and extension boundaries.
 
 ## Runtime service registry
 
-Runtime v0.35.0 provides a public application-scoped service registry with
+Runtime v0.36.0 provides a public application-scoped service registry with
 explicit insertion-ordered registration, stable optional and required lookup,
 immutable discovery snapshots, duplicate protection, and one-way sealing
 before lifecycle composition. This is runtime-owned composition behavior. The
 chart does not declare or discover services, add registry values, load
 plugins, or change lifecycle and pod behavior.
 See the version-pinned
-[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/SERVICE_REGISTRY.md)
+[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/SERVICE_REGISTRY.md)
 for registration, lookup, errors, ownership, privacy, and extension boundaries.
 
 ## Runtime component health
 
-Runtime v0.35.0 lets registered application services opt into bounded component
+Runtime v0.36.0 lets registered application services opt into bounded component
 health reporting. The runtime evaluates checks concurrently under independent
 deadlines, preserves registry order, normalizes failures to stable reason
 codes, emits transition-only structured events, and exposes the informational
@@ -233,12 +233,27 @@ define component checks, health policy, recovery actions, service declarations,
 or a dedicated component-health value. Advanced runtime compositions can pass
 the bounded runtime timeout through the existing `extraConfig` map after their
 own compatibility review. See the version-pinned
-[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/COMPONENT_HEALTH.md)
+[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/COMPONENT_HEALTH.md)
 for status, aggregation, deadline, event, privacy, and extension contracts.
+
+## Core capability registry
+
+Runtime v0.36.0 adds a provider-neutral application-scoped capability registry
+with canonical names, explicit insertion-ordered registration, stable lookup,
+immutable discovery snapshots, duplicate protection, safe errors, one-way
+sealing, and application-owned execution composition. This is runtime-owned
+Python behavior. The chart does not declare capabilities, add registry or
+discovery values, expose an endpoint, load plugins, or change Kubernetes
+resources, probes, settings, or provider behavior. The production runtime
+registers configured chat execution internally under `chat.completions`. See
+the version-pinned
+[runtime capability registry guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/CAPABILITY_REGISTRY.md)
+for identity, registration, lookup, sealing, ownership, compatibility, error,
+privacy, and extension boundaries.
 
 ## Portable runtime dashboards
 
-Runtime v0.35.0 provides three independently importable Grafana dashboard JSON
+Runtime v0.36.0 provides three independently importable Grafana dashboard JSON
 models in the runtime repository:
 
 - `Trussium Runtime Overview` uses Prometheus for demand, active work,
@@ -253,12 +268,12 @@ chart does not bundle, mount, import, or provision dashboard JSON and does not
 install Grafana, any observability backend, a collector, log agent, dashboard
 sidecar, custom resource, or alert. Collection, access control, retention, and
 dashboard lifecycle remain operator-owned. See the
-[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/DASHBOARDS.md)
+[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/DASHBOARDS.md)
 for import, provisioning, variables, privacy, and troubleshooting.
 
 ## Portable runtime alerts
 
-Runtime v0.35.0 provides five portable Prometheus starter alerts for missing
+Runtime v0.36.0 provides five portable Prometheus starter alerts for missing
 telemetry, elevated request failures, elevated cancellations, high p95 latency,
 and process restarts. The published severities, hold times, traffic guards, and
 thresholds are reference values that operators must tune for their SLOs,
@@ -269,7 +284,7 @@ mount, or load them and does not create a rule ConfigMap, `PrometheusRule`,
 `AlertmanagerConfig`, notification route, silence, or monitoring backend.
 Operators own rule loading, target scoping, threshold tuning, routing,
 inhibition, maintenance windows, access control, and retention. See the
-[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.35.0/docs/ALERTING.md)
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/ALERTING.md)
 and the
-[reference rules](https://github.com/trussiumhq/trussium/blob/v0.35.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+[reference rules](https://github.com/trussiumhq/trussium/blob/v0.36.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
 for the complete contract and runbooks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.35.0
+The production Helm chart now carries the validated Trussium v0.36.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.
@@ -33,48 +33,53 @@ Kubernetes contract into an independently released distribution:
   with an intentional sampling and retention policy.
 - Schema, render, package, and Kind upgrade/rollback validation for the full
   tracing configuration contract without chart-owned collector resources.
-- Runtime v0.35.0 outbound W3C `traceparent` and optional `tracestate`
+- Runtime v0.36.0 outbound W3C `traceparent` and optional `tracestate`
   propagation through the existing tracing configuration contract.
 - Explicit runtime privacy boundaries for baggage, request IDs, arbitrary
   headers, payloads, and credentials, without chart-owned receiver resources.
-- Runtime v0.35.0 structured operational events for configuration, provider
+- Runtime v0.36.0 structured operational events for configuration, provider
   readiness, lifecycle, graceful drain, and trace-export failures.
 - Default-deployment validation of safe startup events from live pod logs.
 - Explicit operational-log privacy boundaries without chart-owned collectors,
   shippers, storage backends, dashboards, alerts, sidecars, or volumes.
-- Runtime v0.35.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
+- Runtime v0.36.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
   stable identities and selectable operator-owned data sources.
 - Explicit dashboard ownership boundaries without chart-bundled JSON,
   ConfigMaps, sidecars, custom resources, monitoring backends, or alerts.
 - Version-pinned dashboard import, collection, privacy, and troubleshooting
   guidance linked from chart operations documentation.
-- Runtime v0.35.0 portable Prometheus starter alerts and operator runbooks for
+- Runtime v0.36.0 portable Prometheus starter alerts and operator runbooks for
   missing telemetry, request failures, cancellations, latency, and restarts.
 - Explicit alerting ownership boundaries without chart-bundled rules,
   ConfigMaps, `PrometheusRule`, `AlertmanagerConfig`, notification routing, or
   monitoring backends.
 - Version-pinned alert adoption, tuning, routing, lifecycle, privacy, and
   troubleshooting guidance linked from chart operations documentation.
-- Runtime v0.35.0 dependency-aware readiness settings for opt-in provider
+- Runtime v0.36.0 dependency-aware readiness settings for opt-in provider
   metadata and required-model checks, with bounded timeout and cache controls.
 - Backward-compatible disabled defaults, conditional required-model rendering,
   strict value validation, and live install/upgrade/rollback coverage.
 - Version-pinned health, rollout, privacy, ownership, and troubleshooting
   guidance without chart-managed credentials, providers, or model servers.
-- Runtime v0.35.0 public exception hierarchy compatibility guidance without new
+- Runtime v0.36.0 public exception hierarchy compatibility guidance without new
   chart values, templates, resources, or deployment behavior.
-- Runtime v0.35.0 service lifecycle compatibility guidance for ordered startup,
+- Runtime v0.36.0 service lifecycle compatibility guidance for ordered startup,
   reverse shutdown, partial-startup rollback, bounded cleanup, cancellation,
   and safe failure reporting without chart-owned services, hooks, values, or
   resources.
-- Runtime v0.35.0 service registry compatibility guidance for explicit ordered
+- Runtime v0.36.0 service registry compatibility guidance for explicit ordered
   registration, stable lookup, immutable discovery, duplicate protection, and
   sealed lifecycle ownership without chart-owned registry declarations,
   plugins, health aggregation, values, templates, or resources.
-- Runtime v0.35.0 component health compatibility guidance and live endpoint
+- Runtime v0.36.0 component health compatibility guidance and live endpoint
   validation for bounded statuses, concurrent deadlines, deterministic
   aggregation, transition events, and informational HTTP behavior without new
   chart values, probes, templates, resources, or recovery policy.
+- Runtime v0.36.0 core capability registry compatibility guidance for canonical
+  identities, explicit ordered registration, stable lookup, immutable
+  discovery, duplicate protection, safe errors, sealing, and application-owned
+  execution composition without chart-owned capability declarations,
+  discovery endpoints, plugins, values, templates, probes, or resources.
 
 The immediate focus is runtime compatibility operations: automated runtime
 version proposals, an explicit compatibility matrix, release recovery

--- a/scripts/chart-smoke-test.sh
+++ b/scripts/chart-smoke-test.sh
@@ -168,6 +168,9 @@ if kubectl --context "$context" --namespace "$namespace" get configmap trussium 
     exit 1
 fi
 
+kubectl --context "$context" --namespace "$namespace" exec deployment/trussium -- \
+    python -c "from trussium.capabilities import CHAT_CAPABILITY_NAME, CapabilityRegistry; capability = object(); registry = CapabilityRegistry(); assert registry.register(CHAT_CAPABILITY_NAME, capability) is capability; assert registry.seal()[0].capability is capability"
+
 port="$(python3 -c 'import socket; sock = socket.socket(); sock.bind(("127.0.0.1", 0)); print(sock.getsockname()[1]); sock.close()')"
 kubectl --context "$context" --namespace "$namespace" port-forward service/trussium \
     "$port:9000" >"$port_forward_log" 2>&1 &

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 3
 image:
-  tag: "0.35.0"
+  tag: "0.36.0"
 autoscaling:
   enabled: false
 readiness:

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -47,39 +47,43 @@ def test_chart_metadata_tracks_runtime_independently() -> None:
     assert metadata["type"] == "application"
     assert re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])
     assert metadata["version"] == project["project"]["version"]
-    assert metadata["appVersion"] == "0.35.0"
+    assert metadata["appVersion"] == "0.36.0"
     assert metadata["annotations"]["artifacthub.io/operator"] == "false"
 
 
-def test_kind_validates_runtime_v035_component_health_contract() -> None:
-    """Compatibility CI should bind the release and component health contract."""
+def test_kind_validates_runtime_v036_capability_registry_contract() -> None:
+    """Compatibility CI should bind the release and capability registry contract."""
     workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     smoke_script = (REPOSITORY_ROOT / "scripts" / "chart-smoke-test.sh").read_text()
     root_readme = (REPOSITORY_ROOT / "README.md").read_text()
     chart_readme = (CHART / "README.md").read_text()
 
-    assert "ref: v0.35.0" in workflow
+    assert "ref: v0.36.0" in workflow
     assert '"event":"runtime.configuration.loaded"' in smoke_script
     assert '"event":"provider.configuration.unavailable"' in smoke_script
     assert '"event":"observability.configuration.loaded"' in smoke_script
     assert '"event":"runtime.started"' in smoke_script
     assert '"event":"readiness.configuration.loaded"' in smoke_script
-    assert "blob/v0.35.0/docs/ERRORS.md" in root_readme
-    assert "blob/v0.35.0/docs/ERRORS.md" in chart_readme
-    assert "blob/v0.35.0/docs/LIFECYCLE.md" in root_readme
-    assert "blob/v0.35.0/docs/LIFECYCLE.md" in chart_readme
-    assert "blob/v0.35.0/docs/SERVICE_REGISTRY.md" in root_readme
-    assert "blob/v0.35.0/docs/SERVICE_REGISTRY.md" in chart_readme
-    assert "blob/v0.35.0/docs/COMPONENT_HEALTH.md" in root_readme
-    assert "blob/v0.35.0/docs/COMPONENT_HEALTH.md" in chart_readme
-    assert "blob/v0.35.0/docs/HEALTH.md" in root_readme
-    assert "blob/v0.35.0/docs/HEALTH.md" in chart_readme
-    assert "blob/v0.35.0/docs/DASHBOARDS.md" in root_readme
-    assert "blob/v0.35.0/docs/DASHBOARDS.md" in chart_readme
-    assert "blob/v0.35.0/docs/ALERTING.md" in root_readme
-    assert "blob/v0.35.0/docs/ALERTING.md" in chart_readme
-    assert "blob/v0.35.0/deploy/observability/prometheus/rules/" in root_readme
-    assert "blob/v0.35.0/deploy/observability/prometheus/rules/" in chart_readme
+    assert "CHAT_CAPABILITY_NAME" in smoke_script
+    assert "CapabilityRegistry" in smoke_script
+    assert "blob/v0.36.0/docs/ERRORS.md" in root_readme
+    assert "blob/v0.36.0/docs/ERRORS.md" in chart_readme
+    assert "blob/v0.36.0/docs/LIFECYCLE.md" in root_readme
+    assert "blob/v0.36.0/docs/LIFECYCLE.md" in chart_readme
+    assert "blob/v0.36.0/docs/SERVICE_REGISTRY.md" in root_readme
+    assert "blob/v0.36.0/docs/SERVICE_REGISTRY.md" in chart_readme
+    assert "blob/v0.36.0/docs/COMPONENT_HEALTH.md" in root_readme
+    assert "blob/v0.36.0/docs/COMPONENT_HEALTH.md" in chart_readme
+    assert "blob/v0.36.0/docs/CAPABILITY_REGISTRY.md" in root_readme
+    assert "blob/v0.36.0/docs/CAPABILITY_REGISTRY.md" in chart_readme
+    assert "blob/v0.36.0/docs/HEALTH.md" in root_readme
+    assert "blob/v0.36.0/docs/HEALTH.md" in chart_readme
+    assert "blob/v0.36.0/docs/DASHBOARDS.md" in root_readme
+    assert "blob/v0.36.0/docs/DASHBOARDS.md" in chart_readme
+    assert "blob/v0.36.0/docs/ALERTING.md" in root_readme
+    assert "blob/v0.36.0/docs/ALERTING.md" in chart_readme
+    assert "blob/v0.36.0/deploy/observability/prometheus/rules/" in root_readme
+    assert "blob/v0.36.0/deploy/observability/prometheus/rules/" in chart_readme
     assert "/health/components" in smoke_script
     assert '{"status":"ok","components":[]}' in smoke_script
     assert 'helm --kube-context "$context" get manifest' in smoke_script
@@ -114,7 +118,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert pod_spec["securityContext"]["runAsGroup"] == 10001
     assert pod_spec["securityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
     assert pod_spec["imagePullSecrets"] == [{"name": "ghcr-credentials"}]
-    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.35.0"
+    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.36.0"
     assert container["ports"][0]["containerPort"] == 9000
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]


### PR DESCRIPTION
Closes #29

## Summary

Update the official `trussium` chart's default compatibility target from runtime v0.35.0 to v0.36.0 and validate the additive core capability registry contract.

This is a compatibility-only chart update. It pins the released runtime, verifies the registry API inside the real deployed pod, and documents the ownership boundary without adding chart configuration or Kubernetes resources.

## Runtime release evidence

- Release: https://github.com/trussiumhq/trussium/releases/tag/v0.36.0
- Image: `ghcr.io/trussiumhq/trussium:0.36.0`
- OCI digest: `sha256:7889c6a88e708cc031990af3986ec0674bfeddb51153afb58d33a102e5d38228`
- Platforms: `linux/amd64` and `linux/arm64`
- Wheel and source distribution installation validation: passed
- Capability registry guide: https://github.com/trussiumhq/trussium/blob/v0.36.0/docs/CAPABILITY_REGISTRY.md

## Changes

### Runtime compatibility pin

- Set chart `appVersion` to `0.36.0` while retaining the pre-release chart source version `0.4.4`.
- Make an empty `image.tag` render `ghcr.io/trussiumhq/trussium:0.36.0`.
- Update the custom-values fixture and hosted compatibility checkout to v0.36.0.
- Record chart v0.4.5/runtime v0.36.x in the compatibility matrix.

### Capability registry validation

- Import the public canonical name and registry types inside the deployed runtime pod.
- Register `chat.completions`, verify identity-preserving registration, seal the registry, and verify its immutable composition snapshot.
- Preserve the existing live HTTP validation for startup, liveness, readiness, metrics, request correlation, and component health.
- Keep capability registration and application composition entirely runtime-owned.

### Documentation

- Add capability registry compatibility and ownership guidance to both repository and packaged-chart READMEs.
- Link the version-pinned capability registry, component health, service registry, lifecycle, health, error, dashboard, and alerting contracts.
- Explain canonical identities, ordered registration, stable lookup, immutable discovery, duplicate protection, safe errors, sealing, and application-owned execution composition.
- Update the Helm roadmap and retain the previous compatibility rows.

## Compatibility and boundaries

- No values or value-schema changes.
- No template, probe, or rendered-resource changes.
- No new endpoints, Secrets, RBAC, CRDs, providers, capability declarations, plugins, discovery surfaces, health policies, recovery actions, or operators.
- No changes to lifecycle, registry ownership, readiness, tracing, metrics, autoscaling, security, or graceful shutdown.
- The production runtime continues to register configured chat execution internally; Helm does not expose capability wiring.

## Validation

- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy tests`
- `uv run pytest -q` — 20 passed
- `git diff --check`
- `scripts/helm-validate.sh`
- `scripts/chart-package.sh`
- Complete local Kind lifecycle against runtime v0.36.0: install, in-pod registry API check, live autoscaling, metrics, component health, readiness, tracing configuration upgrade, fixed scaling, rollback, and uninstall

## Checklist

- [x] Runtime v0.36.0 release packages and multi-platform image are verified.
- [x] Default chart image and hosted compatibility CI use v0.36.0.
- [x] The public capability registry contract is validated inside the deployed runtime pod.
- [x] Existing values, schema, templates, probes, and rendered resource kinds are unchanged.
- [x] Compatibility documentation and roadmap are complete.
- [x] Source, package, render, and real-Kubernetes validation pass.
