### PR TITLE
feat(runtime): support capability availability v0.41.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: trussiumhq/trussium
-          ref: v0.40.0
+          ref: v0.41.0
           path: runtime
 
       - name: Install Helm

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ The chart defaults to the compatible runtime release in `Chart.yaml`'s
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
-| `0.4.8` | `0.40.x` | `>=1.25` |
+| `0.5.0` | `0.41.x` | `>=1.25` |
+| `0.4.9` | `0.40.x` | `>=1.25` |
+| `0.4.8` | `0.39.x` | `>=1.25` |
 | `0.4.7` | `0.38.x` | `>=1.25` |
 | `0.4.6` | `0.37.x` | `>=1.25` |
 | `0.4.5` | `0.36.x` | `>=1.25` |
@@ -131,7 +133,7 @@ referenced. The chart never accepts or renders credential values.
 
 ## Dependency-aware readiness
 
-Runtime v0.40.0 can make `/health/ready` reflect provider metadata access and,
+Runtime v0.41.0 can make `/health/ready` reflect provider metadata access and,
 optionally, the availability of a required model. The chart keeps these checks
 disabled by default so installs without provider configuration retain the
 existing `{"status":"ok"}` readiness response.
@@ -164,7 +166,7 @@ visible to anyone who can read the ConfigMap, so do not put credentials,
 provider endpoints, or other secrets in these values. The chart never creates
 provider credentials, installs a provider or model server, downloads models,
 or performs inference. See the version-pinned
-[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/HEALTH.md)
+[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/HEALTH.md)
 for response reasons, rollout guidance, privacy boundaries, and
 troubleshooting.
 
@@ -239,7 +241,7 @@ choose sampling and retention policies appropriate to the cluster. Do not put
 collector credentials in `extraConfig`; use an organization-managed network
 or secret-based integration outside the chart.
 
-Runtime v0.40.0 propagates W3C `traceparent` and optional `tracestate` from the
+Runtime v0.41.0 propagates W3C `traceparent` and optional `tracestate` from the
 active provider span to supported OpenAI and Ollama-compatible JSON and SSE
 requests. It does not propagate baggage, request IDs, arbitrary inbound
 headers, prompts, completions, bodies, or credentials as tracing metadata. A
@@ -248,7 +250,7 @@ own span; the chart does not install or instrument that receiver. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
 for the complete span, privacy, lifecycle, sampling, and propagation contract.
 
-Runtime v0.40.0 also emits newline-delimited structured operational JSON for
+Runtime v0.41.0 also emits newline-delimited structured operational JSON for
 safe configuration summaries, provider configuration readiness, application
 and server lifecycle, graceful-drain outcomes, invalid configuration, and
 trace-export failures. Provider configuration events describe local setup;
@@ -261,34 +263,34 @@ shipper, storage backend, dashboard, or alert. See the
 [runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
 for the stable event and privacy contract.
 
-Runtime v0.40.0 adds a public typed hierarchy for Trussium-owned
+Runtime v0.41.0 adds a public typed hierarchy for Trussium-owned
 configuration, lifecycle, dependency, capability, and provider failures. This
 is an additive application API: it does not change the chart, runtime settings,
 HTTP or SSE error envelopes, cancellation, or Kubernetes behavior. See the
-[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/ERRORS.md)
+[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/ERRORS.md)
 for stable codes, catch boundaries, compatibility, and privacy rules.
 
-Runtime v0.40.0 adds a typed asynchronous lifecycle contract for
+Runtime v0.41.0 adds a typed asynchronous lifecycle contract for
 application-scoped runtime services with declaration-order startup,
 reverse-order shutdown, partial-startup rollback, and bounded per-hook cleanup.
 This is a runtime composition API: the chart does not declare services or
 hooks, add a lifecycle value, or change pod termination behavior. Operators can
 still pass advanced runtime environment settings through the existing
 `extraConfig` map after their own compatibility review. See the version-pinned
-[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/LIFECYCLE.md)
+[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/LIFECYCLE.md)
 for ordering, failure, cancellation, privacy, and extension boundaries.
 
-Runtime v0.40.0 provides a public application-scoped service registry with
+Runtime v0.41.0 provides a public application-scoped service registry with
 explicit insertion-ordered registration, stable optional and required lookup,
 immutable discovery snapshots, duplicate protection, and one-way sealing
 before lifecycle composition. This remains a runtime application API: the
 chart does not declare or discover services, add registry values, load
 plugins, or change lifecycle and pod behavior.
 See the version-pinned
-[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/SERVICE_REGISTRY.md)
+[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/SERVICE_REGISTRY.md)
 for registration, lookup, errors, ownership, privacy, and extension boundaries.
 
-Runtime v0.40.0 lets registered application services opt into bounded component
+Runtime v0.41.0 lets registered application services opt into bounded component
 health reporting. The runtime evaluates checks concurrently under independent
 deadlines, preserves registry order, normalizes failures to stable reason
 codes, emits transition-only structured events, and exposes the informational
@@ -302,10 +304,10 @@ define component checks, health policy, recovery actions, service declarations,
 or a dedicated component-health value. Advanced runtime compositions can pass
 the bounded runtime timeout through the existing `extraConfig` map after their
 own compatibility review. See the version-pinned
-[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/COMPONENT_HEALTH.md)
+[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/COMPONENT_HEALTH.md)
 for status, aggregation, deadline, event, privacy, and extension contracts.
 
-Runtime v0.40.0 adds a provider-neutral application-scoped capability registry
+Runtime v0.41.0 adds a provider-neutral application-scoped capability registry
 with canonical names, explicit insertion-ordered registration, stable lookup,
 immutable discovery snapshots, duplicate protection, safe errors, one-way
 sealing, and application-owned execution composition. This is an additive
@@ -314,60 +316,85 @@ discovery values, expose an endpoint, load plugins, or change Kubernetes
 resources, probes, settings, or provider behavior. The production runtime
 registers configured chat execution internally under `chat.completions`. See
 the version-pinned
-[runtime capability registry guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/CAPABILITY_REGISTRY.md)
+[runtime capability registry guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_REGISTRY.md)
 for identity, registration, lookup, sealing, ownership, compatibility, error,
 privacy, and extension boundaries.
 
-Runtime v0.40.0 adds frozen, bounded metadata to capability registrations and
+Runtime v0.41.0 adds frozen, bounded metadata to capability registrations and
 an ordered `GET /v1/capabilities` discovery endpoint. Provider-free deployments
 return `{"capabilities":[]}`. The response deliberately excludes provider,
 model, implementation, health, availability, and configuration data. This
 runtime-owned contract adds no chart values, templates, resources, probes, or
 permissions. See the version-pinned
-[runtime capability discovery guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/CAPABILITY_DISCOVERY.md)
+[runtime capability discovery guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_DISCOVERY.md)
 for response shape, ordering, privacy, compatibility, and ownership boundaries.
 
-Runtime v0.40.0 adds a sealed-registry-backed provider-neutral execution
+Runtime v0.41.0 adds a sealed-registry-backed provider-neutral execution
 pipeline for asynchronous and streaming capability work. It preserves context,
 results, events, native failures, cancellation, and upstream cleanup while the
 existing chat JSON/SSE telemetry and transport contracts remain unchanged. The
 pipeline is runtime-owned and adds no chart value, template, resource, probe,
 permission, endpoint, or configuration. See the version-pinned
-[runtime capability execution pipeline guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/CAPABILITY_EXECUTION_PIPELINE.md)
+[runtime capability execution pipeline guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_EXECUTION_PIPELINE.md)
 for composition, invocation, cleanup, compatibility, and ownership boundaries.
 
-Runtime v0.40.0 adds ordered provider-neutral capability middleware around the
+Runtime v0.41.0 adds ordered provider-neutral capability middleware around the
 execution pipeline. Application composition can observe immutable invocation
 metadata, continue once, or short-circuit asynchronous and streaming work while
 the runtime preserves context, failures, event identity, and deterministic
 cleanup. Middleware remains runtime-owned and adds no chart value, template,
 resource, probe, permission, endpoint, environment setting, or routing policy.
 See the version-pinned
-[runtime capability middleware guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/CAPABILITY_MIDDLEWARE.md)
+[runtime capability middleware guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_MIDDLEWARE.md)
 for contracts, ordering, cleanup, compatibility, and ownership boundaries.
 
-Runtime v0.40.0 lets registered capabilities optionally own application-scoped
+Runtime v0.41.0 lets registered capabilities optionally own application-scoped
 resources through ordered asynchronous startup, reverse shutdown,
 partial-startup rollback, bounded cleanup, deterministic state, and safe
 operational failures. Ordinary capabilities remain unchanged. Lifecycle is a
 runtime-owned Python contract and adds no chart value, schema, template,
 resource, probe, permission, endpoint, environment setting, CRD, or operator
 behavior. See the version-pinned
-[runtime capability lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/CAPABILITY_LIFECYCLE.md)
+[runtime capability lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_LIFECYCLE.md)
 for ownership, ordering, cleanup, cancellation, errors, events, privacy, and
 extension boundaries.
 
-Runtime v0.40.0 provides three portable Grafana dashboard JSON models in the
+## Capability availability reporting
+
+Runtime v0.41.0 gives every registered capability a bounded informational
+availability state. Ordinary registrations default to available; optional
+checks run concurrently under a runtime-owned deadline, preserve registry
+order, normalize failures to stable reasons, and emit transition-only events.
+The read-only `GET /v1/capabilities/availability` endpoint always returns HTTP
+200 and is not a startup, liveness, or readiness probe.
+
+The chart exposes only the positive per-check deadline:
+
+```yaml
+runtime:
+  capabilityAvailabilityTimeoutSeconds: 1
+```
+
+This renders
+`TRUSSIUM_RUNTIME__CAPABILITY_AVAILABILITY_TIMEOUT_SECONDS`. Changing it does
+not gate execution or add routing, retry, fallback, recovery, capability
+declarations, Kubernetes probes, resources, permissions, CRDs, or operator
+behavior. The provider-free chart response is
+`{"status":"available","capabilities":[]}`. See the version-pinned
+[runtime capability availability guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_AVAILABILITY.md)
+for values, aggregation, failures, events, privacy, and extension boundaries.
+
+Runtime v0.41.0 provides three portable Grafana dashboard JSON models in the
 runtime repository: a Prometheus overview, a Loki structured-log view, and a
 Tempo trace investigation view. Prometheus is required only for the overview;
 Loki and Tempo remain optional. The chart does not bundle, mount, import, or
 provision those files and does not install Grafana, observability backends,
 collectors, log agents, dashboard custom resources, or alerts. Operators own
 data collection, dashboard import, backend access control, and retention. See
-the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/DASHBOARDS.md)
+the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/DASHBOARDS.md)
 for artifacts, import methods, variables, privacy, and troubleshooting.
 
-Runtime v0.40.0 also provides five portable Prometheus starter alerts for
+Runtime v0.41.0 also provides five portable Prometheus starter alerts for
 missing telemetry, elevated request failures, elevated cancellations, high p95
 latency, and process restarts. Their severity, hold times, traffic guards, and
 thresholds are reference values that operators must review against their SLOs,
@@ -378,9 +405,9 @@ load them and does not create a rule ConfigMap, `PrometheusRule`,
 `AlertmanagerConfig`, notification route, silence, or monitoring backend.
 Operators own rule loading, target scoping, threshold tuning, routing,
 inhibition, maintenance windows, access control, and retention. See the
-[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/ALERTING.md)
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/ALERTING.md)
 and the
-[reference rules](https://github.com/trussiumhq/trussium/blob/v0.40.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+[reference rules](https://github.com/trussiumhq/trussium/blob/v0.41.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
 for the complete contract and runbooks.
 
 The complete value reference is in the
@@ -439,12 +466,13 @@ scripts/helm-validate.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.40.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.41.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
 autoscaling, runtime metrics, tracing configuration, operational startup logs,
-default component health, ordered capability discovery, dependency readiness,
-readiness configuration upgrade and rollback, HTTP request correlation,
-fixed-scale upgrade, autoscaling rollback, and uninstall:
+default component health, ordered capability discovery, empty capability
+availability, dependency readiness, availability-timeout configuration,
+upgrade and rollback, HTTP request correlation, fixed-scale upgrade,
+autoscaling rollback, and uninstall:
 
 ```bash
 TRUSSIUM_RUNTIME_SOURCE=../trussium scripts/chart-smoke-test.sh

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.4.9
-appVersion: "0.40.0"
+appVersion: "0.41.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -31,6 +31,7 @@ default compatible runtime image.
 | `runtime.host` | `0.0.0.0` | Runtime bind host. |
 | `runtime.port` | `9000` | Container and runtime port. |
 | `runtime.gracefulShutdownSeconds` | `30` | Active-workload drain deadline. |
+| `runtime.capabilityAvailabilityTimeoutSeconds` | `1` | Positive deadline for one capability availability check. |
 | `timeouts.providerRequestSeconds` | `60` | Provider request deadline. |
 | `timeouts.streamIdleSeconds` | `30` | Streaming event idle deadline. |
 | `readiness.dependencyChecksEnabled` | `false` | Include provider metadata access in runtime readiness. |
@@ -92,7 +93,7 @@ Prometheus Adapter, ServiceMonitor, or other monitoring resources.
 
 ## Dependency-aware readiness
 
-Runtime v0.40.0 can include provider metadata access in `/health/ready`. The
+Runtime v0.41.0 can include provider metadata access in `/health/ready`. The
 chart preserves backward-compatible behavior by disabling dependency checks by
 default:
 
@@ -121,7 +122,7 @@ provider availability. The required-model identifier is non-secret ConfigMap
 data visible to anyone who can read that resource; do not place credentials,
 provider endpoints, or other secrets in readiness values. See the
 version-pinned
-[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/HEALTH.md)
+[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/HEALTH.md)
 for response reasons, rollout guidance, privacy boundaries, and
 troubleshooting.
 
@@ -153,7 +154,7 @@ network and secret controls. The runtime excludes health and metrics traffic
 and does not attach prompts, bodies, credentials, query strings, raw URLs, or
 exception messages to spans.
 
-With runtime v0.40.0, the active provider span is propagated to supported
+With runtime v0.41.0, the active provider span is propagated to supported
 OpenAI and Ollama-compatible JSON and SSE requests as W3C `traceparent` and
 optional `tracestate`. Baggage, request IDs, arbitrary inbound headers,
 payloads, and credentials remain behind the runtime privacy boundary. The
@@ -164,7 +165,7 @@ for the complete contract.
 
 ## Structured operational logs
 
-Runtime v0.40.0 writes bounded newline-delimited JSON events to standard
+Runtime v0.41.0 writes bounded newline-delimited JSON events to standard
 output for startup configuration, provider configuration readiness,
 observability enablement, application and server shutdown, graceful-drain
 timeouts, invalid settings, and trace-export failures.
@@ -185,16 +186,16 @@ for the stable event table and privacy boundary.
 
 ## Runtime exception hierarchy
 
-Runtime v0.40.0 adds public typed bases for Trussium-owned configuration,
+Runtime v0.41.0 adds public typed bases for Trussium-owned configuration,
 lifecycle, dependency, capability, and provider failures. This additive Python
 API changes no chart values, templates, HTTP or SSE envelopes, cancellation,
 or Kubernetes resources. See the version-pinned
-[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/ERRORS.md)
+[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/ERRORS.md)
 for stable codes, catch boundaries, compatibility, and privacy rules.
 
 ## Runtime service lifecycle
 
-Runtime v0.40.0 adds a typed asynchronous lifecycle contract for
+Runtime v0.41.0 adds a typed asynchronous lifecycle contract for
 application-scoped runtime services with declaration-order startup,
 reverse-order shutdown, partial-startup rollback, and bounded per-hook cleanup.
 This is runtime-owned composition behavior. The chart does not declare
@@ -202,24 +203,24 @@ services or hooks, add a dedicated cleanup value, or change pod termination
 behavior. Operators may pass advanced runtime environment settings through the
 existing `extraConfig` map after their own compatibility review. See the
 version-pinned
-[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/LIFECYCLE.md)
+[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/LIFECYCLE.md)
 for ordering, failure, cancellation, privacy, and extension boundaries.
 
 ## Runtime service registry
 
-Runtime v0.40.0 provides a public application-scoped service registry with
+Runtime v0.41.0 provides a public application-scoped service registry with
 explicit insertion-ordered registration, stable optional and required lookup,
 immutable discovery snapshots, duplicate protection, and one-way sealing
 before lifecycle composition. This is runtime-owned composition behavior. The
 chart does not declare or discover services, add registry values, load
 plugins, or change lifecycle and pod behavior.
 See the version-pinned
-[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/SERVICE_REGISTRY.md)
+[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/SERVICE_REGISTRY.md)
 for registration, lookup, errors, ownership, privacy, and extension boundaries.
 
 ## Runtime component health
 
-Runtime v0.40.0 lets registered application services opt into bounded component
+Runtime v0.41.0 lets registered application services opt into bounded component
 health reporting. The runtime evaluates checks concurrently under independent
 deadlines, preserves registry order, normalizes failures to stable reason
 codes, emits transition-only structured events, and exposes the informational
@@ -233,12 +234,12 @@ define component checks, health policy, recovery actions, service declarations,
 or a dedicated component-health value. Advanced runtime compositions can pass
 the bounded runtime timeout through the existing `extraConfig` map after their
 own compatibility review. See the version-pinned
-[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/COMPONENT_HEALTH.md)
+[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/COMPONENT_HEALTH.md)
 for status, aggregation, deadline, event, privacy, and extension contracts.
 
 ## Core capability registry
 
-Runtime v0.40.0 adds a provider-neutral application-scoped capability registry
+Runtime v0.41.0 adds a provider-neutral application-scoped capability registry
 with canonical names, explicit insertion-ordered registration, stable lookup,
 immutable discovery snapshots, duplicate protection, safe errors, one-way
 sealing, and application-owned execution composition. This is runtime-owned
@@ -247,60 +248,85 @@ discovery values, expose an endpoint, load plugins, or change Kubernetes
 resources, probes, settings, or provider behavior. The production runtime
 registers configured chat execution internally under `chat.completions`. See
 the version-pinned
-[runtime capability registry guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/CAPABILITY_REGISTRY.md)
+[runtime capability registry guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_REGISTRY.md)
 for identity, registration, lookup, sealing, ownership, compatibility, error,
 privacy, and extension boundaries.
 
 ## Capability metadata and discovery
 
-Runtime v0.40.0 adds frozen, bounded metadata to capability registrations and
+Runtime v0.41.0 adds frozen, bounded metadata to capability registrations and
 an ordered `GET /v1/capabilities` discovery endpoint. Provider-free deployments
 return `{"capabilities":[]}`. The response deliberately excludes provider,
 model, implementation, health, availability, and configuration data. This is a
 runtime-owned contract: the chart adds no values, templates, resources, probes,
 or permissions. See the version-pinned
-[runtime capability discovery guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/CAPABILITY_DISCOVERY.md)
+[runtime capability discovery guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_DISCOVERY.md)
 for response shape, ordering, privacy, compatibility, and ownership boundaries.
 
 ## Capability execution pipeline
 
-Runtime v0.40.0 adds a sealed-registry-backed provider-neutral execution
+Runtime v0.41.0 adds a sealed-registry-backed provider-neutral execution
 pipeline for asynchronous and streaming capability work. It preserves context,
 results, events, native failures, cancellation, and upstream cleanup while the
 existing chat JSON/SSE telemetry and transport contracts remain unchanged. The
 pipeline is runtime-owned and adds no chart value, template, resource, probe,
 permission, endpoint, or configuration. See the version-pinned
-[runtime capability execution pipeline guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/CAPABILITY_EXECUTION_PIPELINE.md)
+[runtime capability execution pipeline guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_EXECUTION_PIPELINE.md)
 for composition, invocation, cleanup, compatibility, and ownership boundaries.
 
 ## Capability middleware
 
-Runtime v0.40.0 adds ordered provider-neutral capability middleware around the
+Runtime v0.41.0 adds ordered provider-neutral capability middleware around the
 execution pipeline. Application composition can observe immutable invocation
 metadata, continue once, or short-circuit asynchronous and streaming work while
 the runtime preserves context, failures, event identity, and deterministic
 cleanup. Middleware remains runtime-owned and adds no chart value, template,
 resource, probe, permission, endpoint, environment setting, or routing policy.
 See the version-pinned
-[runtime capability middleware guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/CAPABILITY_MIDDLEWARE.md)
+[runtime capability middleware guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_MIDDLEWARE.md)
 for contracts, ordering, cleanup, compatibility, and ownership boundaries.
 
 ## Capability lifecycle management
 
-Runtime v0.40.0 lets registered capabilities optionally own application-scoped
+Runtime v0.41.0 lets registered capabilities optionally own application-scoped
 resources through ordered asynchronous startup, reverse shutdown,
 partial-startup rollback, bounded cleanup, deterministic state, and safe
 operational failures. Ordinary capabilities remain unchanged. Lifecycle is a
 runtime-owned Python contract and adds no chart value, schema, template,
 resource, probe, permission, endpoint, environment setting, CRD, or operator
 behavior. See the version-pinned
-[runtime capability lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/CAPABILITY_LIFECYCLE.md)
+[runtime capability lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_LIFECYCLE.md)
 for ownership, ordering, cleanup, cancellation, errors, events, privacy, and
 extension boundaries.
 
+## Capability availability reporting
+
+Runtime v0.41.0 gives every registered capability a bounded informational
+availability state. Ordinary registrations default to available; optional
+checks run concurrently under a runtime-owned deadline, preserve registry
+order, normalize failures to stable reasons, and emit transition-only events.
+The read-only `GET /v1/capabilities/availability` endpoint always returns HTTP
+200 and is not a startup, liveness, or readiness probe.
+
+The chart exposes only the positive per-check deadline:
+
+```yaml
+runtime:
+  capabilityAvailabilityTimeoutSeconds: 1
+```
+
+This renders
+`TRUSSIUM_RUNTIME__CAPABILITY_AVAILABILITY_TIMEOUT_SECONDS`. Changing it does
+not gate execution or add routing, retry, fallback, recovery, capability
+declarations, Kubernetes probes, resources, permissions, CRDs, or operator
+behavior. The provider-free chart response is
+`{"status":"available","capabilities":[]}`. See the version-pinned
+[runtime capability availability guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_AVAILABILITY.md)
+for values, aggregation, failures, events, privacy, and extension boundaries.
+
 ## Portable runtime dashboards
 
-Runtime v0.40.0 provides three independently importable Grafana dashboard JSON
+Runtime v0.41.0 provides three independently importable Grafana dashboard JSON
 models in the runtime repository:
 
 - `Trussium Runtime Overview` uses Prometheus for demand, active work,
@@ -315,12 +341,12 @@ chart does not bundle, mount, import, or provision dashboard JSON and does not
 install Grafana, any observability backend, a collector, log agent, dashboard
 sidecar, custom resource, or alert. Collection, access control, retention, and
 dashboard lifecycle remain operator-owned. See the
-[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/DASHBOARDS.md)
+[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/DASHBOARDS.md)
 for import, provisioning, variables, privacy, and troubleshooting.
 
 ## Portable runtime alerts
 
-Runtime v0.40.0 provides five portable Prometheus starter alerts for missing
+Runtime v0.41.0 provides five portable Prometheus starter alerts for missing
 telemetry, elevated request failures, elevated cancellations, high p95 latency,
 and process restarts. The published severities, hold times, traffic guards, and
 thresholds are reference values that operators must tune for their SLOs,
@@ -331,7 +357,7 @@ mount, or load them and does not create a rule ConfigMap, `PrometheusRule`,
 `AlertmanagerConfig`, notification route, silence, or monitoring backend.
 Operators own rule loading, target scoping, threshold tuning, routing,
 inhibition, maintenance windows, access control, and retention. See the
-[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.40.0/docs/ALERTING.md)
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/ALERTING.md)
 and the
-[reference rules](https://github.com/trussiumhq/trussium/blob/v0.40.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+[reference rules](https://github.com/trussiumhq/trussium/blob/v0.41.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
 for the complete contract and runbooks.

--- a/charts/trussium/templates/configmap.yaml
+++ b/charts/trussium/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
   TRUSSIUM_RUNTIME__HOST: {{ .Values.runtime.host | quote }}
   TRUSSIUM_RUNTIME__PORT: {{ .Values.runtime.port | quote }}
   TRUSSIUM_RUNTIME__GRACEFUL_SHUTDOWN_SECONDS: {{ .Values.runtime.gracefulShutdownSeconds | quote }}
+  TRUSSIUM_RUNTIME__CAPABILITY_AVAILABILITY_TIMEOUT_SECONDS: {{ .Values.runtime.capabilityAvailabilityTimeoutSeconds | quote }}
   TRUSSIUM_TIMEOUTS__PROVIDER_REQUEST_SECONDS: {{ .Values.timeouts.providerRequestSeconds | quote }}
   TRUSSIUM_TIMEOUTS__STREAM_IDLE_SECONDS: {{ .Values.timeouts.streamIdleSeconds | quote }}
   TRUSSIUM_READINESS__DEPENDENCY_CHECKS_ENABLED: {{ .Values.readiness.dependencyChecksEnabled | quote }}

--- a/charts/trussium/values.schema.json
+++ b/charts/trussium/values.schema.json
@@ -79,12 +79,22 @@
     "runtime": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["environment", "host", "port", "gracefulShutdownSeconds"],
+      "required": [
+        "environment",
+        "host",
+        "port",
+        "gracefulShutdownSeconds",
+        "capabilityAvailabilityTimeoutSeconds"
+      ],
       "properties": {
         "environment": {"type": "string", "minLength": 1},
         "host": {"type": "string", "minLength": 1},
         "port": {"type": "integer", "minimum": 1, "maximum": 65535},
-        "gracefulShutdownSeconds": {"type": "integer", "minimum": 0}
+        "gracefulShutdownSeconds": {"type": "integer", "minimum": 0},
+        "capabilityAvailabilityTimeoutSeconds": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        }
       }
     },
     "timeouts": {

--- a/charts/trussium/values.yaml
+++ b/charts/trussium/values.yaml
@@ -44,6 +44,7 @@ runtime:
   host: 0.0.0.0
   port: 9000
   gracefulShutdownSeconds: 30
+  capabilityAvailabilityTimeoutSeconds: 1
 
 timeouts:
   providerRequestSeconds: 60

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.40.0
+The production Helm chart now carries the validated Trussium v0.41.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.
@@ -33,68 +33,75 @@ Kubernetes contract into an independently released distribution:
   with an intentional sampling and retention policy.
 - Schema, render, package, and Kind upgrade/rollback validation for the full
   tracing configuration contract without chart-owned collector resources.
-- Runtime v0.40.0 outbound W3C `traceparent` and optional `tracestate`
+- Runtime v0.41.0 outbound W3C `traceparent` and optional `tracestate`
   propagation through the existing tracing configuration contract.
 - Explicit runtime privacy boundaries for baggage, request IDs, arbitrary
   headers, payloads, and credentials, without chart-owned receiver resources.
-- Runtime v0.40.0 structured operational events for configuration, provider
+- Runtime v0.41.0 structured operational events for configuration, provider
   readiness, lifecycle, graceful drain, and trace-export failures.
 - Default-deployment validation of safe startup events from live pod logs.
 - Explicit operational-log privacy boundaries without chart-owned collectors,
   shippers, storage backends, dashboards, alerts, sidecars, or volumes.
-- Runtime v0.40.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
+- Runtime v0.41.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
   stable identities and selectable operator-owned data sources.
 - Explicit dashboard ownership boundaries without chart-bundled JSON,
   ConfigMaps, sidecars, custom resources, monitoring backends, or alerts.
 - Version-pinned dashboard import, collection, privacy, and troubleshooting
   guidance linked from chart operations documentation.
-- Runtime v0.40.0 portable Prometheus starter alerts and operator runbooks for
+- Runtime v0.41.0 portable Prometheus starter alerts and operator runbooks for
   missing telemetry, request failures, cancellations, latency, and restarts.
 - Explicit alerting ownership boundaries without chart-bundled rules,
   ConfigMaps, `PrometheusRule`, `AlertmanagerConfig`, notification routing, or
   monitoring backends.
 - Version-pinned alert adoption, tuning, routing, lifecycle, privacy, and
   troubleshooting guidance linked from chart operations documentation.
-- Runtime v0.40.0 dependency-aware readiness settings for opt-in provider
+- Runtime v0.41.0 dependency-aware readiness settings for opt-in provider
   metadata and required-model checks, with bounded timeout and cache controls.
 - Backward-compatible disabled defaults, conditional required-model rendering,
   strict value validation, and live install/upgrade/rollback coverage.
 - Version-pinned health, rollout, privacy, ownership, and troubleshooting
   guidance without chart-managed credentials, providers, or model servers.
-- Runtime v0.40.0 public exception hierarchy compatibility guidance without new
+- Runtime v0.41.0 public exception hierarchy compatibility guidance without new
   chart values, templates, resources, or deployment behavior.
-- Runtime v0.40.0 service lifecycle compatibility guidance for ordered startup,
+- Runtime v0.41.0 service lifecycle compatibility guidance for ordered startup,
   reverse shutdown, partial-startup rollback, bounded cleanup, cancellation,
   and safe failure reporting without chart-owned services, hooks, values, or
   resources.
-- Runtime v0.40.0 service registry compatibility guidance for explicit ordered
+- Runtime v0.41.0 service registry compatibility guidance for explicit ordered
   registration, stable lookup, immutable discovery, duplicate protection, and
   sealed lifecycle ownership without chart-owned registry declarations,
   plugins, health aggregation, values, templates, or resources.
-- Runtime v0.40.0 component health compatibility guidance and live endpoint
+- Runtime v0.41.0 component health compatibility guidance and live endpoint
   validation for bounded statuses, concurrent deadlines, deterministic
   aggregation, transition events, and informational HTTP behavior without new
   chart values, probes, templates, resources, or recovery policy.
-- Runtime v0.40.0 core capability registry compatibility guidance for canonical
+- Runtime v0.41.0 core capability registry compatibility guidance for canonical
   identities, explicit ordered registration, stable lookup, immutable
   discovery, duplicate protection, safe errors, sealing, and application-owned
   execution composition without chart-owned capability declarations,
   discovery endpoints, plugins, values, templates, probes, or resources.
-- Runtime v0.40.0 bounded immutable capability metadata and ordered external
+- Runtime v0.41.0 bounded immutable capability metadata and ordered external
   discovery guidance, with live provider-free `GET /v1/capabilities` validation
   and no chart-owned configuration, declarations, templates, resources, probes,
   permissions, provider details, model details, or availability policy.
-- Runtime v0.40.0 sealed-registry capability execution pipeline compatibility
+- Runtime v0.41.0 sealed-registry capability execution pipeline compatibility
   guidance and live in-pod invocation without chart-owned middleware, routing,
   values, templates, resources, probes, permissions, or execution policy.
-- Runtime v0.40.0 ordered capability middleware compatibility guidance and live
+- Runtime v0.41.0 ordered capability middleware compatibility guidance and live
   in-pod invocation without chart-owned middleware configuration, declarations,
   routing, values, templates, resources, probes, permissions, or execution
   policy.
-- Runtime v0.40.0 optional capability lifecycle compatibility guidance and live
+- Runtime v0.41.0 optional capability lifecycle compatibility guidance and live
   in-pod startup and shutdown validation without chart-owned lifecycle values,
   declarations, templates, resources, probes, permissions, CRDs, or operator
   behavior.
+- Runtime v0.41.0 capability availability compatibility guidance, positive
+  schema-validated per-check deadline, ConfigMap rendering, public contract
+  import, and live provider-free endpoint validation.
+- Explicit separation of informational capability availability from execution,
+  routing, retry, recovery, and Kubernetes startup, liveness, and readiness
+  probes, without chart-owned declarations, resources, permissions, CRDs, or
+  operator behavior.
 
 The immediate focus is runtime compatibility operations: automated runtime
 version proposals, an explicit compatibility matrix, release recovery

--- a/scripts/chart-smoke-test.sh
+++ b/scripts/chart-smoke-test.sh
@@ -162,6 +162,9 @@ assert_equal "$(kubectl --context "$context" --namespace "$namespace" get config
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
     -o jsonpath='{.data.TRUSSIUM_READINESS__DEPENDENCY_CACHE_SECONDS}')" \
     "10" "default dependency readiness cache"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_RUNTIME__CAPABILITY_AVAILABILITY_TIMEOUT_SECONDS}')" \
+    "1" "default capability availability timeout"
 if kubectl --context "$context" --namespace "$namespace" get configmap trussium -o json | \
     grep -q 'TRUSSIUM_READINESS__REQUIRED_MODEL'; then
     echo "default ConfigMap unexpectedly rendered a required readiness model" >&2
@@ -170,6 +173,8 @@ fi
 
 kubectl --context "$context" --namespace "$namespace" exec deployment/trussium -- \
     python -c "import asyncio; from trussium.capabilities import CHAT_CAPABILITY_METADATA, CHAT_CAPABILITY_NAME, CapabilityExecutionPipeline, CapabilityInvocation, CapabilityLifecycle, CapabilityLifecycleState, CapabilityRegistry; capability = object(); managed = type('ManagedCapability', (), {'startup': lambda self: asyncio.sleep(0), 'shutdown': lambda self: asyncio.sleep(0)})(); registry = CapabilityRegistry(); assert registry.register(CHAT_CAPABILITY_NAME, capability, metadata=CHAT_CAPABILITY_METADATA) is capability; registry.register('managed', managed); assert registry.seal()[0].metadata is CHAT_CAPABILITY_METADATA; lifecycle = CapabilityLifecycle(registry); assert lifecycle.names == ('managed',); asyncio.run(lifecycle.startup()); assert lifecycle.state is CapabilityLifecycleState.STARTED; asyncio.run(lifecycle.shutdown()); assert lifecycle.state is CapabilityLifecycleState.STOPPED; invocations = []; middleware = type('SmokeMiddleware', (), {'execute': lambda self, invocation, call_next: (invocations.append(invocation), call_next())[1], 'stream': lambda self, invocation, call_next: call_next()})(); pipeline = CapabilityExecutionPipeline(registry, middleware=(middleware,)); assert asyncio.run(pipeline.execute(CHAT_CAPABILITY_NAME, lambda resolved: asyncio.sleep(0, result=resolved))) is capability; assert pipeline.middleware == (middleware,); assert len(invocations) == 1; assert isinstance(invocations[0], CapabilityInvocation); assert invocations[0].capability is capability"
+kubectl --context "$context" --namespace "$namespace" exec deployment/trussium -- \
+    python -c "import asyncio; from trussium.capabilities import CapabilityAvailabilityReporter, CapabilityAvailabilityStatus, CapabilityRegistry; registry = CapabilityRegistry(); registry.seal(); report = asyncio.run(CapabilityAvailabilityReporter(registry).report()); assert report.status is CapabilityAvailabilityStatus.AVAILABLE; assert report.capabilities == ()"
 
 port="$(python3 -c 'import socket; sock = socket.socket(); sock.bind(("127.0.0.1", 0)); print(sock.getsockname()[1]); sock.close()')"
 kubectl --context "$context" --namespace "$namespace" port-forward service/trussium \
@@ -210,6 +215,11 @@ curl --fail --silent --show-error "http://127.0.0.1:$port/v1/capabilities" \
 assert_equal "$(cat "$body")" \
     '{"capabilities":[]}' "capability discovery response"
 
+curl --fail --silent --show-error \
+    "http://127.0.0.1:$port/v1/capabilities/availability" --output "$body"
+assert_equal "$(cat "$body")" \
+    '{"status":"available","capabilities":[]}' "capability availability response"
+
 curl --fail --silent --show-error "http://127.0.0.1:$port/metrics" --output "$body"
 grep -q '^trussium_http_requests_active 0\.0$' "$body"
 grep -q '^process_start_time_seconds ' "$body"
@@ -217,6 +227,7 @@ grep -q '^process_start_time_seconds ' "$body"
 kubectl --context "$context" --namespace "$namespace" logs \
     -l app.kubernetes.io/name=trussium --tail=100 >"$runtime_log"
 grep -q '"event":"runtime.configuration.loaded"' "$runtime_log"
+grep -q '"capability_availability_timeout_seconds":1.0' "$runtime_log"
 grep -q '"event":"provider.configuration.unavailable"' "$runtime_log"
 grep -q '"event":"observability.configuration.loaded"' "$runtime_log"
 grep -q '"event":"readiness.configuration.loaded"' "$runtime_log"
@@ -236,6 +247,7 @@ helm --kube-context "$context" upgrade "$release" "$repository_root/charts/truss
     --set-json observability.tracing.otlpExportTimeoutSeconds=2.5 \
     --set-json readiness.dependencyTimeoutSeconds=0.75 \
     --set-json readiness.dependencyCacheSeconds=3.5 \
+    --set-json runtime.capabilityAvailabilityTimeoutSeconds=0.625 \
     --set-string readiness.requiredModel=required-model --wait --timeout 180s
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get deployment trussium \
     -o jsonpath='{.status.readyReplicas}')" "3" "ready replicas after upgrade"
@@ -271,6 +283,9 @@ assert_equal "$(kubectl --context "$context" --namespace "$namespace" get config
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
     -o jsonpath='{.data.TRUSSIUM_READINESS__REQUIRED_MODEL}')" \
     "required-model" "upgraded required readiness model"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_RUNTIME__CAPABILITY_AVAILABILITY_TIMEOUT_SECONDS}')" \
+    "0.625" "upgraded capability availability timeout"
 
 helm --kube-context "$context" rollback "$release" 1 --namespace "$namespace" --wait --timeout 180s
 wait_for_autoscaling
@@ -282,6 +297,9 @@ assert_equal "$(kubectl --context "$context" --namespace "$namespace" get config
 assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
     -o jsonpath='{.data.TRUSSIUM_READINESS__DEPENDENCY_TIMEOUT_SECONDS}')" \
     "1" "dependency readiness timeout after rollback"
+assert_equal "$(kubectl --context "$context" --namespace "$namespace" get configmap trussium \
+    -o jsonpath='{.data.TRUSSIUM_RUNTIME__CAPABILITY_AVAILABILITY_TIMEOUT_SECONDS}')" \
+    "1" "capability availability timeout after rollback"
 if kubectl --context "$context" --namespace "$namespace" get configmap trussium -o json | \
     grep -q 'TRUSSIUM_READINESS__REQUIRED_MODEL'; then
     echo "rollback ConfigMap retained the required readiness model" >&2

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,8 @@
 replicaCount: 3
 image:
-  tag: "0.40.0"
+  tag: "0.41.0"
+runtime:
+  capabilityAvailabilityTimeoutSeconds: 0.625
 autoscaling:
   enabled: false
 readiness:

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -47,18 +47,18 @@ def test_chart_metadata_tracks_runtime_independently() -> None:
     assert metadata["type"] == "application"
     assert re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])
     assert metadata["version"] == project["project"]["version"]
-    assert metadata["appVersion"] == "0.40.0"
+    assert metadata["appVersion"] == "0.41.0"
     assert metadata["annotations"]["artifacthub.io/operator"] == "false"
 
 
-def test_kind_validates_runtime_v040_capability_lifecycle() -> None:
-    """Compatibility CI should bind the release and lifecycle contract."""
+def test_kind_validates_runtime_v041_capability_availability() -> None:
+    """Compatibility CI should bind the release and availability contract."""
     workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     smoke_script = (REPOSITORY_ROOT / "scripts" / "chart-smoke-test.sh").read_text()
     root_readme = (REPOSITORY_ROOT / "README.md").read_text()
     chart_readme = (CHART / "README.md").read_text()
 
-    assert "ref: v0.40.0" in workflow
+    assert "ref: v0.41.0" in workflow
     assert '"event":"runtime.configuration.loaded"' in smoke_script
     assert '"event":"provider.configuration.unavailable"' in smoke_script
     assert '"event":"observability.configuration.loaded"' in smoke_script
@@ -74,34 +74,44 @@ def test_kind_validates_runtime_v040_capability_lifecycle() -> None:
     assert "CapabilityRegistry" in smoke_script
     assert "CapabilityLifecycle" in smoke_script
     assert "CapabilityLifecycleState" in smoke_script
+    assert "CapabilityAvailabilityReporter" in smoke_script
+    assert "CapabilityAvailabilityStatus" in smoke_script
     assert '"http://127.0.0.1:$port/v1/capabilities"' in smoke_script
     assert "capability discovery response" in smoke_script
-    assert "blob/v0.40.0/docs/ERRORS.md" in root_readme
-    assert "blob/v0.40.0/docs/ERRORS.md" in chart_readme
-    assert "blob/v0.40.0/docs/LIFECYCLE.md" in root_readme
-    assert "blob/v0.40.0/docs/LIFECYCLE.md" in chart_readme
-    assert "blob/v0.40.0/docs/SERVICE_REGISTRY.md" in root_readme
-    assert "blob/v0.40.0/docs/SERVICE_REGISTRY.md" in chart_readme
-    assert "blob/v0.40.0/docs/COMPONENT_HEALTH.md" in root_readme
-    assert "blob/v0.40.0/docs/COMPONENT_HEALTH.md" in chart_readme
-    assert "blob/v0.40.0/docs/CAPABILITY_REGISTRY.md" in root_readme
-    assert "blob/v0.40.0/docs/CAPABILITY_REGISTRY.md" in chart_readme
-    assert "blob/v0.40.0/docs/CAPABILITY_DISCOVERY.md" in root_readme
-    assert "blob/v0.40.0/docs/CAPABILITY_DISCOVERY.md" in chart_readme
-    assert "blob/v0.40.0/docs/CAPABILITY_EXECUTION_PIPELINE.md" in root_readme
-    assert "blob/v0.40.0/docs/CAPABILITY_EXECUTION_PIPELINE.md" in chart_readme
-    assert "blob/v0.40.0/docs/CAPABILITY_MIDDLEWARE.md" in root_readme
-    assert "blob/v0.40.0/docs/CAPABILITY_MIDDLEWARE.md" in chart_readme
-    assert "blob/v0.40.0/docs/CAPABILITY_LIFECYCLE.md" in root_readme
-    assert "blob/v0.40.0/docs/CAPABILITY_LIFECYCLE.md" in chart_readme
-    assert "blob/v0.40.0/docs/HEALTH.md" in root_readme
-    assert "blob/v0.40.0/docs/HEALTH.md" in chart_readme
-    assert "blob/v0.40.0/docs/DASHBOARDS.md" in root_readme
-    assert "blob/v0.40.0/docs/DASHBOARDS.md" in chart_readme
-    assert "blob/v0.40.0/docs/ALERTING.md" in root_readme
-    assert "blob/v0.40.0/docs/ALERTING.md" in chart_readme
-    assert "blob/v0.40.0/deploy/observability/prometheus/rules/" in root_readme
-    assert "blob/v0.40.0/deploy/observability/prometheus/rules/" in chart_readme
+    assert '"http://127.0.0.1:$port/v1/capabilities/availability"' in smoke_script
+    assert "capability availability response" in smoke_script
+    assert "blob/v0.41.0/docs/ERRORS.md" in root_readme
+    assert "blob/v0.41.0/docs/ERRORS.md" in chart_readme
+    assert "blob/v0.41.0/docs/LIFECYCLE.md" in root_readme
+    assert "blob/v0.41.0/docs/LIFECYCLE.md" in chart_readme
+    assert "blob/v0.41.0/docs/SERVICE_REGISTRY.md" in root_readme
+    assert "blob/v0.41.0/docs/SERVICE_REGISTRY.md" in chart_readme
+    assert "blob/v0.41.0/docs/COMPONENT_HEALTH.md" in root_readme
+    assert "blob/v0.41.0/docs/COMPONENT_HEALTH.md" in chart_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_REGISTRY.md" in root_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_REGISTRY.md" in chart_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_DISCOVERY.md" in root_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_DISCOVERY.md" in chart_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_EXECUTION_PIPELINE.md" in root_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_EXECUTION_PIPELINE.md" in chart_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_MIDDLEWARE.md" in root_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_MIDDLEWARE.md" in chart_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_LIFECYCLE.md" in root_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_LIFECYCLE.md" in chart_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_AVAILABILITY.md" in root_readme
+    assert "blob/v0.41.0/docs/CAPABILITY_AVAILABILITY.md" in chart_readme
+    assert "blob/v0.41.0/docs/HEALTH.md" in root_readme
+    assert "blob/v0.41.0/docs/HEALTH.md" in chart_readme
+    assert "blob/v0.41.0/docs/DASHBOARDS.md" in root_readme
+    assert "blob/v0.41.0/docs/DASHBOARDS.md" in chart_readme
+    assert "blob/v0.41.0/docs/ALERTING.md" in root_readme
+    assert "blob/v0.41.0/docs/ALERTING.md" in chart_readme
+    assert "blob/v0.41.0/deploy/observability/prometheus/rules/" in root_readme
+    assert "blob/v0.41.0/deploy/observability/prometheus/rules/" in chart_readme
+    assert "| `0.5.0` | `0.41.x` | `>=1.25` |" in root_readme
+    assert "| `0.4.9` | `0.40.x` | `>=1.25` |" in root_readme
+    assert "| `0.4.8` | `0.39.x` | `>=1.25` |" in root_readme
+    assert '"capability_availability_timeout_seconds":1.0' in smoke_script
     assert "/health/components" in smoke_script
     assert '{"status":"ok","components":[]}' in smoke_script
     assert 'helm --kube-context "$context" get manifest' in smoke_script
@@ -136,7 +146,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert pod_spec["securityContext"]["runAsGroup"] == 10001
     assert pod_spec["securityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
     assert pod_spec["imagePullSecrets"] == [{"name": "ghcr-credentials"}]
-    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.40.0"
+    assert container["image"] == "ghcr.io/trussiumhq/trussium:0.41.0"
     assert container["ports"][0]["containerPort"] == 9000
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]
@@ -165,6 +175,7 @@ def test_default_render_preserves_production_runtime_contract() -> None:
     assert budget["spec"]["maxUnavailable"] == 1
 
     config_map = resource(documents, "ConfigMap")
+    assert config_map["data"]["TRUSSIUM_RUNTIME__CAPABILITY_AVAILABILITY_TIMEOUT_SECONDS"] == "1"
     assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_CHECKS_ENABLED"] == "false"
     assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_TIMEOUT_SECONDS"] == "1"
     assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_CACHE_SECONDS"] == "10"
@@ -248,6 +259,9 @@ def test_custom_values_render_supported_integrations() -> None:
     assert service["metadata"]["annotations"]["example.com/service"] == "custom"
 
     config_map = resource(documents, "ConfigMap")
+    assert (
+        config_map["data"]["TRUSSIUM_RUNTIME__CAPABILITY_AVAILABILITY_TIMEOUT_SECONDS"] == "0.625"
+    )
     assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_CHECKS_ENABLED"] == "true"
     assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_TIMEOUT_SECONDS"] == "0.75"
     assert config_map["data"]["TRUSSIUM_READINESS__DEPENDENCY_CACHE_SECONDS"] == "3.5"
@@ -360,6 +374,46 @@ def test_schema_rejects_unknown_readiness_values() -> None:
     assert result.returncode != 0
     assert "unexpected" in result.stderr
     assert "Additional property" in result.stderr
+
+
+def test_schema_rejects_unknown_runtime_values() -> None:
+    result = run_helm(
+        "template",
+        "trussium",
+        str(CHART),
+        "--set",
+        "runtime.unexpected=true",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "unexpected" in result.stderr
+    assert "Additional property" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("flag", "value"),
+    [
+        ("--set", "0"),
+        ("--set", "-1"),
+        ("--set-string", "invalid"),
+    ],
+)
+def test_schema_rejects_invalid_capability_availability_deadline(
+    flag: str,
+    value: str,
+) -> None:
+    result = run_helm(
+        "template",
+        "trussium",
+        str(CHART),
+        flag,
+        f"runtime.capabilityAvailabilityTimeoutSeconds={value}",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "capabilityAvailabilityTimeoutSeconds" in result.stderr
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #39

## Summary

Add Helm support for Trussium runtime v0.41.0 capability availability reporting.

## What changed

- Update the default runtime image and compatibility CI checkout to v0.41.0.
- Add runtime.capabilityAvailabilityTimeoutSeconds (default 1) with strict positive-number validation.
- Render TRUSSIUM_RUNTIME__CAPABILITY_AVAILABILITY_TIMEOUT_SECONDS in the runtime ConfigMap.
- Cover default and custom rendering, invalid and unknown values, live endpoint behavior, and upgrade/rollback configuration restoration.
- Correct the published compatibility history: chart 0.4.8 targets runtime 0.39.x, chart 0.4.9 targets 0.40.x, and the forthcoming chart 0.5.0 targets 0.41.x.

## Architecture / design notes

Capability availability is an informational runtime contract. The chart exposes only its bounded per-check deadline; it does not declare capabilities, gate execution, add routing or recovery behavior, or alter startup, liveness, or readiness probes.

The chart continues to install only the Trussium runtime. It does not install or configure trussium-operator, CRDs, credentials, provider/model services, observability backends, dashboards, or alerts.

## Testing

- Added schema, render, compatibility, and documentation assertions.
- Extended the Kind smoke test to validate the empty availability report, runtime configuration loading, custom-timeout upgrade, and rollback restoration.

## Validation

- uv run ruff format --check .
- uv run ruff check .
- uv run mypy tests
- uv run pytest -q: 24 passed
- scripts/helm-validate.sh
- scripts/chart-package.sh
- Full Kind install, runtime endpoint, upgrade, rollback, and uninstall smoke test against runtime v0.41.0

## Documentation

Updated the root and chart READMEs and the complete Helm roadmap with configuration, compatibility, operational boundaries, and validation coverage.

## Related issue

Closes #39