### PR TITLE
docs: add project maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,11 @@
+# Trussium Maintainers
+
+This file lists the maintainers responsible for the Trussium project and its
+Runtime, Kubernetes Operator, Helm chart, and documentation portal.
+
+| Maintainer | GitHub ID | Company/Organization |
+| --- | --- | --- |
+| Timothy Nyachio | [@sartim](https://github.com/sartim) | Trussium |
+
+Maintainer responsibilities and appointment process are defined in the
+[project governance](https://github.com/trussiumhq/trussiumhq.github.io/blob/main/GOVERNANCE.md).


### PR DESCRIPTION
Adds the canonical Trussium maintainer roster required for CNCF Sandbox readiness.