### PR TITLE
feat: update default runtime compatibility to v0.67.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ scripts/chart-contract-test.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.41.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.67.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
 autoscaling, runtime metrics, tracing configuration, operational startup logs,
 default component health, ordered capability discovery, empty capability

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.5.0
-appVersion: "0.41.0"
+appVersion: "0.67.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.41.0
+The production Helm chart now carries the validated Trussium v0.67.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.

--- a/scripts/chart-contract-test.sh
+++ b/scripts/chart-contract-test.sh
@@ -71,7 +71,7 @@ assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.secur
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.securityContext.seccompProfile.type' "$default_render")" \
     "RuntimeDefault" "seccomp profile"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].image' "$default_render")" \
-    "ghcr.io/trussiumhq/trussium:0.41.0" "default runtime image"
+    "ghcr.io/trussiumhq/trussium:0.67.0" "default runtime image"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' "$default_render")" \
     "9000" "runtime port"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem' "$default_render")" \

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 3
 image:
-  tag: "0.41.0"
+  tag: "0.67.0"
 runtime:
   capabilityAvailabilityTimeoutSeconds: 0.625
 autoscaling:


### PR DESCRIPTION
Closes #43

## Summary
- update chart appVersion to the current runtime v0.67.0
- refresh chart tests and custom-value fixtures
- update runtime chart documentation and roadmap
- coordinate the compatibility contract with trussium-operator

## Validation
- uv run pytest
- scripts/helm-validate.sh
- git diff --check