### PR TITLE
docs: publish chart runtime compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,15 @@ helm install trussium \
 
 The chart defaults to the compatible runtime release in `Chart.yaml`'s
 `appVersion`. Chart and runtime versions are intentionally independent.
+See the [compatibility policy and matrix](docs/COMPATIBILITY.md) for supported
+chart/runtime combinations and upgrade ownership.
 
 ## Compatibility
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
-| `0.5.0` | `0.41.x` | `>=1.25` |
+| `0.6.x` | `0.67.x` | `>=1.25` |
+| `0.5.x` | `0.41.x` | `>=1.25` |
 | `0.4.9` | `0.40.x` | `>=1.25` |
 | `0.4.8` | `0.39.x` | `>=1.25` |
 | `0.4.7` | `0.38.x` | `>=1.25` |

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,41 @@
+# Chart and runtime compatibility
+
+The Helm chart and Trussium runtime are released independently. A chart release
+records its default runtime target in `charts/trussium/Chart.yaml` under
+`appVersion`; the chart version controls the templates, schema, and packaging.
+
+## Supported matrix
+
+| Chart release | Default runtime image | Kubernetes |
+| --- | --- | --- |
+| `0.6.x` | `0.67.x` | `>=1.25` |
+| `0.5.x` | `0.41.x` | `>=1.25` |
+| `0.4.9` | `0.40.x` | `>=1.25` |
+| `0.4.8` | `0.39.x` | `>=1.25` |
+| `0.4.7` | `0.38.x` | `>=1.25` |
+| `0.4.6` | `0.37.x` | `>=1.25` |
+| `0.4.5` | `0.36.x` | `>=1.25` |
+| `0.4.4` | `0.35.x` | `>=1.25` |
+| `0.4.3` | `0.34.x` | `>=1.25` |
+| `0.4.2` | `0.33.x` | `>=1.25` |
+| `0.4.1` | `0.32.x` | `>=1.25` |
+| `0.4.0` | `0.31.x` | `>=1.25` |
+
+The current release is the first row. Historical rows preserve the documented
+compatibility targets for existing installations.
+
+## Policy
+
+Compatibility is established by rendering and live lifecycle validation of the
+default runtime image with the chart. A runtime compatibility update must also
+update `Chart.yaml`, the contract test image assertion, this matrix, and the
+release notes or roadmap entry in the same change.
+
+The chart requires Kubernetes `>=1.25`. Kubernetes support is a chart contract,
+not a runtime version guarantee; cluster admission, storage, networking, and
+provider connectivity remain operator responsibilities.
+
+Overriding `image.tag` is supported for operators who have validated that
+runtime against the chart. The chart cannot guarantee compatibility for an
+arbitrary image override and does not automatically select or install runtime
+versions.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -4,6 +4,11 @@ Chart releases use Conventional Commits and Python Semantic Release. The chart
 version is independent from the Trussium runtime version. `Chart.yaml`'s
 `appVersion` records the default runtime compatibility target.
 
+When the default runtime changes, update the [compatibility policy and
+matrix](COMPATIBILITY.md), the chart contract test, and the roadmap in the same
+pull request. The change must be validated against the runtime lifecycle before
+release.
+
 On a merge to `main`, the release workflow:
 
 1. Calculates the next semantic chart version.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -121,10 +121,10 @@ runbooks, and validation across supported Kubernetes minor versions.
 
 ## Milestone 2 — Runtime compatibility operations
 
-**Status:** Planned
+**Status:** In Progress
 
 - Automate proposals for newly released compatible runtime versions.
-- Publish an explicit chart-to-runtime compatibility policy and matrix.
+- [x] Publish an explicit chart-to-runtime compatibility policy and matrix.
 - Add release recovery and OCI publication recovery runbooks.
 - Validate supported Kubernetes minor versions in CI.
 


### PR DESCRIPTION
Closes #47

## Summary

Publish the chart-to-runtime compatibility policy and matrix for the released
Helm chart.

## Changes

- Document the current `0.6.x` / runtime `0.67.x` / Kubernetes `>=1.25` contract.
- Preserve historical chart/runtime compatibility rows.
- Define ownership and validation rules for runtime image overrides.
- Add release-maintenance guidance and update the roadmap.

## Validation

- `scripts/helm-validate.sh`
- `scripts/chart-contract-test.sh`
- `scripts/chart-package.sh`
- `git diff --check`

## Compatibility

Documentation-only change; rendered resources and deployment behavior are
unchanged.
