### PR TITLE
feat: automate runtime compatibility proposals

### DIFF
--- a/.github/workflows/runtime-proposal.yml
+++ b/.github/workflows/runtime-proposal.yml
@@ -1,0 +1,65 @@
+name: Runtime Compatibility Proposal
+
+on:
+  schedule:
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      runtime_version:
+        description: "Optional runtime version to propose (for example 0.68.0)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  propose:
+    name: Propose compatible runtime update
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.16.3
+
+      - name: Install yq
+        uses: mikefarah/yq@v4.45.1
+
+      - name: Propose runtime update
+        env:
+          TRUSSIUM_RUNTIME_VERSION: ${{ inputs.runtime_version }}
+        run: scripts/propose-runtime-update.sh
+
+      - name: Validate proposal
+        run: |
+          scripts/helm-validate.sh
+          scripts/chart-contract-test.sh
+
+      - name: Open compatibility proposal
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/runtime-compatibility
+          delete-branch: true
+          title: "feat: update runtime compatibility"
+          commit-message: "feat: update runtime compatibility"
+          body: |
+            Closes #49
+
+            ## Summary
+
+            Propose the latest Trussium runtime compatibility target.
+
+            ## Validation
+
+            - `scripts/helm-validate.sh`
+            - `scripts/chart-contract-test.sh`
+
+            This proposal is review-only. It does not merge, publish, or deploy
+            a runtime automatically.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -9,6 +9,12 @@ matrix](COMPATIBILITY.md), the chart contract test, and the roadmap in the same
 pull request. The change must be validated against the runtime lifecycle before
 release.
 
+The weekly Runtime Compatibility Proposal workflow checks the latest runtime
+release and opens a review-only pull request when the target changes. A
+maintainer must review the generated compatibility diff and lifecycle checks;
+the workflow never merges, publishes, or deploys automatically. Use its manual
+`runtime_version` input to rehearse a proposal for a specific release.
+
 On a merge to `main`, the release workflow:
 
 1. Calculates the next semantic chart version.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,7 +123,8 @@ runbooks, and validation across supported Kubernetes minor versions.
 
 **Status:** In Progress
 
-- Automate proposals for newly released compatible runtime versions.
+- [x] Automate review-only proposals for newly released compatible runtime
+  versions.
 - [x] Publish an explicit chart-to-runtime compatibility policy and matrix.
 - Add release recovery and OCI publication recovery runbooks.
 - Validate supported Kubernetes minor versions in CI.

--- a/scripts/propose-runtime-update.sh
+++ b/scripts/propose-runtime-update.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -eu
+
+repository_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+chart_file="$repository_root/charts/trussium/Chart.yaml"
+contract_file="$repository_root/scripts/chart-contract-test.sh"
+readme_file="$repository_root/README.md"
+compatibility_file="$repository_root/docs/COMPATIBILITY.md"
+
+fail() {
+    echo "runtime proposal failure: $*" >&2
+    exit 1
+}
+
+runtime_version="${1:-${TRUSSIUM_RUNTIME_VERSION:-}}"
+if [ -z "$runtime_version" ]; then
+    command -v curl >/dev/null 2>&1 || fail "curl is required for release lookup"
+    command -v jq >/dev/null 2>&1 || fail "jq is required for release lookup"
+    runtime_version="$(curl --fail --silent --show-error --location \
+        -H 'Accept: application/vnd.github+json' \
+        https://api.github.com/repos/trussiumhq/trussium/releases/latest | jq -r '.tag_name')"
+fi
+
+runtime_version="${runtime_version#v}"
+case "$runtime_version" in
+    ''|*[!0-9.]*|*.*.*.*|.*|*.|*..*) fail "runtime version must be semantic, got '$runtime_version'" ;;
+esac
+version_parts=$(printf '%s' "$runtime_version" | awk -F. '{print NF}')
+[ "$version_parts" -eq 3 ] || fail "runtime version must be major.minor.patch, got '$runtime_version'"
+runtime_series="${runtime_version%.*}.x"
+
+current_version="$(sed -n 's/^appVersion: "\([^"]*\)"$/\1/p' "$chart_file")"
+[ -n "$current_version" ] || fail "could not read chart appVersion"
+if [ "$current_version" = "$runtime_version" ]; then
+    echo "Runtime compatibility is already $runtime_version"
+    exit 0
+fi
+
+sed -i.bak 's/^appVersion: ".*"$/appVersion: "'"$runtime_version"'"/' "$chart_file"
+sed -i.bak 's#trussium:[0-9][0-9.]*#trussium:'"$runtime_version"'#' "$contract_file"
+perl -0pi -e 's#(\| `[^`]+` \| )`[0-9]+\.[0-9]+\.x`( \| `>=1\.25` \|)#${1}`'"$runtime_series"'`${2}#' "$readme_file"
+perl -0pi -e 's#(\| `[^`]+` \| )`[0-9]+\.[0-9]+\.x`( \| `>=1\.25` \|)#${1}`'"$runtime_series"'`${2}#' "$compatibility_file"
+rm -f "$chart_file.bak" "$contract_file.bak" "$readme_file.bak" "$compatibility_file.bak"
+
+echo "Proposed runtime compatibility update: $current_version -> $runtime_version"


### PR DESCRIPTION
Closes #49

## Summary

Automate review-only proposals when a newer Trussium runtime release becomes
available.

## Changes

- Add a weekly and manually triggerable GitHub Actions workflow.
- Query the latest runtime release or accept an explicit test version.
- Update `Chart.yaml`, contract assertions, and compatibility tables together.
- Validate proposals with Helm lint, rendering, and contract tests.
- Open a non-merging, non-publishing pull request for maintainer review.
- Document the workflow and update the roadmap.

## Validation

- `sh -n scripts/propose-runtime-update.sh`
- No-op proposal test for runtime `0.67.0`
- Simulated proposal test for runtime `0.68.0`
- `scripts/helm-validate.sh`
- `scripts/chart-contract-test.sh`
- `scripts/chart-package.sh`
- `git diff --check`

## Compatibility

Existing release and deployment workflows are unchanged. Runtime updates remain
reviewed and merged by maintainers.
