### PR TITLE
ci: validate supported Kubernetes versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,32 @@ jobs:
         env:
           TRUSSIUM_KIND_CLUSTER: trussium-helm-ci
           TRUSSIUM_RUNTIME_SOURCE: ${{ github.workspace }}/runtime
+
+  kubernetes:
+    name: Kubernetes ${{ matrix.kube-version }} Compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        kube-version: ["1.25.0", "1.29.0", "1.31.0"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.16.3
+
+      - name: Validate supported Kubernetes version
+        run: scripts/kubernetes-version-test.sh "${{ matrix.kube-version }}"
+
+      - name: Confirm unsupported Kubernetes version is rejected
+        if: matrix.kube-version == '1.25.0'
+        run: |
+          if helm template trussium charts/trussium --kube-version 1.24.0 >/dev/null 2>&1; then
+            echo "Kubernetes 1.24.0 unexpectedly passed the chart support floor" >&2
+            exit 1
+          fi

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -31,7 +31,9 @@ default runtime image with the chart. A runtime compatibility update must also
 update `Chart.yaml`, the contract test image assertion, this matrix, and the
 release notes or roadmap entry in the same change.
 
-The chart requires Kubernetes `>=1.25`. Kubernetes support is a chart contract,
+The chart requires Kubernetes `>=1.25`. CI renders and strictly lints against
+Kubernetes `1.25`, `1.29`, and `1.31`, and confirms that `1.24` is rejected by
+the chart contract. Kubernetes support is a chart contract,
 not a runtime version guarantee; cluster admission, storage, networking, and
 provider connectivity remain operator responsibilities.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,7 +127,7 @@ runbooks, and validation across supported Kubernetes minor versions.
   versions.
 - [x] Publish an explicit chart-to-runtime compatibility policy and matrix.
 - [x] Add release recovery and OCI publication recovery runbooks.
-- Validate supported Kubernetes minor versions in CI.
+- [x] Validate supported Kubernetes minor versions in CI.
 
 ## Milestone 3 — Optional platform integrations
 

--- a/scripts/kubernetes-version-test.sh
+++ b/scripts/kubernetes-version-test.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+repository_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+chart="$repository_root/charts/trussium"
+kube_version="${1:-}"
+
+case "$kube_version" in
+    ''|*[!0-9.]*|*.*.*.*|.*|*.|*..*)
+        echo "usage: $0 MAJOR.MINOR.PATCH" >&2
+        exit 2
+        ;;
+esac
+
+rendered="$(mktemp)"
+trap 'rm -f "$rendered"' EXIT INT TERM
+
+helm lint --strict "$chart" --kube-version "$kube_version"
+helm template trussium "$chart" --namespace trussium-system \
+    --kube-version "$kube_version" >"$rendered"
+
+grep -q '^kind: Deployment$' "$rendered"
+grep -q '^kind: Service$' "$rendered"
+echo "Kubernetes $kube_version chart validation passed"


### PR DESCRIPTION
Closes #53

## Summary

Validate the chart across the Kubernetes minor versions covered by its support
policy.

## Changes

- Add `scripts/kubernetes-version-test.sh` for explicit-version Helm lint and
  rendering checks.
- Add CI coverage for Kubernetes 1.25, 1.29, and 1.31.
- Confirm Kubernetes 1.24 is rejected by the chart contract.
- Document tested versions and update the roadmap.

## Validation

- `scripts/kubernetes-version-test.sh 1.25.0`
- `scripts/kubernetes-version-test.sh 1.29.0`
- `scripts/kubernetes-version-test.sh 1.31.0`
- Kubernetes 1.24 rejection check
- `scripts/helm-validate.sh`
- `scripts/chart-contract-test.sh`
- `git diff --check`

## Compatibility

CI-only validation change; chart templates and deployment behavior are
unchanged.
