### PR TITLE
docs: evaluate NetworkPolicy ownership contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The chart defaults to the compatible runtime release in `Chart.yaml`'s
 `appVersion`. Chart and runtime versions are intentionally independent.
 See the [compatibility policy and matrix](docs/COMPATIBILITY.md) for supported
 chart/runtime combinations and upgrade ownership.
+NetworkPolicy ownership and the requirements for a future opt-in policy are
+documented in the [NetworkPolicy evaluation](docs/NETWORK_POLICY.md).
 
 ## Compatibility
 

--- a/docs/NETWORK_POLICY.md
+++ b/docs/NETWORK_POLICY.md
@@ -1,0 +1,42 @@
+# NetworkPolicy evaluation
+
+The chart does not render a NetworkPolicy today. This is intentional: the
+runtime's network destinations are deployment-specific and a restrictive,
+chart-owned policy could make a valid installation unavailable.
+
+## Traffic contract
+
+| Direction | Traffic | Ownership |
+| --- | --- | --- |
+| Ingress | Client requests to the runtime Service on TCP 9000 | Operator selects clients and any ingress controller or gateway |
+| Egress | Provider API requests and model metadata checks | Operator configures provider endpoints and allowed destinations |
+| Egress | DNS lookups to the cluster DNS service | Cluster platform provides DNS and its service IP |
+| Egress | OTLP HTTP traces when tracing is enabled | Operator supplies the collector endpoint and network path |
+| Ingress | Kubernetes probes to `/health/*` | Chart configures probes; cluster networking must permit them |
+| Ingress | Metrics scraping at `/metrics` when enabled | Operator-owned scraper and selection policy |
+
+The chart cannot infer provider CIDRs, collector addresses, ingress identities,
+DNS service IPs, or scraper namespaces. Provider credentials and endpoints also
+remain outside the chart's ownership boundary.
+
+## Minimum contract for a future opt-in policy
+
+A future policy must be disabled by default and must let operators explicitly
+provide:
+
+- allowed ingress namespace and pod selectors;
+- allowed egress CIDRs or named destinations for providers and collectors;
+- the cluster DNS namespace/pod selector and port 53 UDP/TCP;
+- an explicit metrics-scraper selector, if metrics ingress is restricted.
+
+It must render only `networking.k8s.io/v1`, preserve the runtime Service and
+probe paths, and include contract tests for disabled, ingress-only, and
+fully-configured modes. It must not silently add `0.0.0.0/0` egress as a
+security policy disguised as a default.
+
+## Current recommendation
+
+Keep NetworkPolicy organization-owned until those selectors and destinations
+are known. Teams that require a deny-by-default posture can apply a policy in
+their platform repository, using the traffic table above and validating it
+against their provider and observability topology.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -139,6 +139,8 @@ runbooks, and validation across supported Kubernetes minor versions.
   dashboard or backend resources.
 - [x] Portable runtime alerting compatibility guidance without chart-owned
   rules, notification routing, or backend resources.
+- [x] Evaluate NetworkPolicy traffic and ownership contracts without rendering
+  a potentially unsafe default policy.
 - Optional NetworkPolicy after supported network contracts are defined.
 - Optional ServiceMonitor after observability endpoints stabilize.
 - Optional Ingress integration without owning certificate issuance.

--- a/docs/adr/0002-network-policy-ownership.md
+++ b/docs/adr/0002-network-policy-ownership.md
@@ -1,0 +1,26 @@
+# ADR 0002: Defer chart-owned NetworkPolicy
+
+- Status: Accepted
+- Date: 2026-08-27
+
+## Context
+
+Trussium pods accept operator-selected clients and call operator-selected
+providers and optional telemetry collectors. Kubernetes NetworkPolicy rules
+are namespace- and selector-specific, while the chart cannot discover those
+deployment choices or provider network ranges.
+
+## Decision
+
+Do not render a NetworkPolicy in the chart yet. Document the traffic contract
+and require any future policy to be explicitly opt-in with operator-supplied
+selectors and destinations.
+
+## Consequences
+
+- Existing deployments retain their current connectivity and behavior.
+- Platform teams can apply organization-owned deny policies immediately.
+- A future chart policy must define DNS, provider, collector, probe, and metrics
+  paths before it can be enabled safely.
+- The chart does not provide a false sense of egress restriction through broad
+  or guessed CIDR defaults.


### PR DESCRIPTION
Closes #55

## Summary

Evaluate NetworkPolicy support and document the traffic contract required for a
future safe, opt-in policy.

## Changes

- Document ingress, provider egress, DNS, tracing, probes, and metrics traffic.
- Define required operator selectors and destinations for future policies.
- Record the decision to defer chart-owned NetworkPolicy in ADR 0002.
- Update README and roadmap documentation.
- Keep NetworkPolicy disabled by omission and preserve existing chart behavior.

## Validation

- `scripts/helm-validate.sh`
- `scripts/chart-contract-test.sh`
- `scripts/chart-package.sh`
- `git diff --check`

## Compatibility

Documentation-only change; no resources or deployment behavior change.
