### PR TITLE
docs: evaluate ServiceMonitor ownership contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ Do not manually scale the Deployment while the HPA is enabled. Tune the HPA
 bounds and target instead. See the
 [runtime metrics guide](https://github.com/trussiumhq/trussium/blob/main/docs/METRICS.md)
 for the bounded Prometheus-compatible metric contract and optional custom
-metrics extension point.
+metrics extension point. The chart's ServiceMonitor ownership decision is
+documented in [the ServiceMonitor evaluation](docs/SERVICEMONITOR.md).
 
 OpenTelemetry tracing is disabled by default. The chart can render runtime
 trace enablement, service name, parent-based sample ratio, OTLP HTTP/protobuf

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -90,6 +90,8 @@ replicaCount: 3
 Runtime metrics remain independently configurable through
 `observability.metrics.enabled`. The chart does not install Prometheus,
 Prometheus Adapter, ServiceMonitor, or other monitoring resources.
+See the repository's [ServiceMonitor evaluation](../../docs/SERVICEMONITOR.md)
+for the scraping contract and future opt-in requirements.
 
 ## Dependency-aware readiness
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -142,7 +142,10 @@ runbooks, and validation across supported Kubernetes minor versions.
 - [x] Evaluate NetworkPolicy traffic and ownership contracts without rendering
   a potentially unsafe default policy.
 - Optional NetworkPolicy after supported network contracts are defined.
-- Optional ServiceMonitor after observability endpoints stabilize.
+- [x] Evaluate the ServiceMonitor scraping and ownership contract without
+  rendering a Prometheus Operator custom resource.
+- Optional ServiceMonitor after observability endpoints stabilize and operator
+  selector requirements are agreed.
 - Optional Ingress integration without owning certificate issuance.
 
 ## Boundary

--- a/docs/SERVICEMONITOR.md
+++ b/docs/SERVICEMONITOR.md
@@ -1,0 +1,39 @@
+# ServiceMonitor evaluation
+
+The chart exposes runtime metrics but does not render a `ServiceMonitor`. A
+ServiceMonitor is a Prometheus Operator custom resource, so rendering one
+without confirming that the CRD and controller exist would make otherwise
+valid Helm installs fail or leave a misleading, unscheduled object.
+
+## Scraping contract
+
+| Field | Contract |
+| --- | --- |
+| Service port | Named `http`, default service port `9000` |
+| Metrics path | `/metrics` |
+| Enablement | `observability.metrics.enabled: true` (default) |
+| Protocol | Prometheus text exposition over HTTP |
+| Target | The chart-owned `trussium` Service selecting runtime pods |
+
+The runtime metrics endpoint is independent from the HPA: autoscaling uses
+Kubernetes resource metrics and does not require Prometheus.
+
+## Minimum contract for a future opt-in resource
+
+A future chart option must be disabled by default and require an installed
+Prometheus Operator. Operators must be able to provide the ServiceMonitor
+namespace, labels used by their Prometheus selector, scrape interval, timeout,
+and optional TLS or authorization settings. The chart must not guess those
+values or create Prometheus, RBAC, dashboards, alerts, or monitoring backends.
+
+The option must render only when metrics are enabled and must include contract
+tests for disabled, default opt-in, and custom-selector modes. Kind validation
+should remain provider-free and should not assume a Prometheus Operator is
+installed.
+
+## Current recommendation
+
+Use an organization-owned ServiceMonitor in the platform repository when the
+Prometheus Operator is available. Select the chart Service by its stable
+`app.kubernetes.io/name: trussium` and `app.kubernetes.io/instance` labels,
+target port `http`, and path `/metrics`.

--- a/docs/adr/0003-servicemonitor-ownership.md
+++ b/docs/adr/0003-servicemonitor-ownership.md
@@ -1,0 +1,25 @@
+# ADR 0003: Defer chart-owned ServiceMonitor
+
+- Status: Accepted
+- Date: 2026-08-27
+
+## Context
+
+ServiceMonitor is not a built-in Kubernetes resource; it is supplied by the
+Prometheus Operator. Clusters differ in CRD installation, Prometheus selector
+labels, namespace selection, scrape policy, and authorization requirements.
+
+## Decision
+
+Do not render a ServiceMonitor in the chart yet. Document the stable metrics
+endpoint and require any future resource to be explicitly opt-in with
+operator-supplied selector and scrape settings.
+
+## Consequences
+
+- Metrics remain available through the existing Service without new chart
+  dependencies or CRDs.
+- Platform teams can create a ServiceMonitor that matches their Prometheus
+  deployment today.
+- A future chart option must verify CRD/controller assumptions and preserve the
+  current metrics-disabled behavior.


### PR DESCRIPTION
Closes #57

## Summary

Evaluate ServiceMonitor support and document the Prometheus scraping contract.

## Changes

- Document the stable metrics Service port, path, and enablement behavior.
- Define future opt-in ServiceMonitor selector, scrape, TLS, and authorization
  requirements.
- Record ADR 0003 deferring chart-owned ServiceMonitor resources.
- Update root/chart README documentation and roadmap.
- Preserve default chart behavior and avoid a Prometheus Operator dependency.

## Validation

- `scripts/helm-validate.sh`
- `scripts/chart-contract-test.sh`
- `scripts/chart-package.sh`
- `git diff --check`

## Compatibility

Documentation-only change; no resources or deployment behavior change.
