### PR TITLE
docs: evaluate Ingress ownership contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ See the [compatibility policy and matrix](docs/COMPATIBILITY.md) for supported
 chart/runtime combinations and upgrade ownership.
 NetworkPolicy ownership and the requirements for a future opt-in policy are
 documented in the [NetworkPolicy evaluation](docs/NETWORK_POLICY.md).
+Ingress and certificate ownership are covered in the
+[Ingress evaluation](docs/INGRESS.md).
 
 ## Compatibility
 

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -27,6 +27,7 @@ default compatible runtime image.
 | `service.type` | `ClusterIP` | Kubernetes Service type. |
 | `service.port` | `9000` | Service port. |
 | `service.annotations` | `{}` | Service annotations. |
+| Ingress | not rendered | See the repository's Ingress evaluation before composing external routing. |
 | `runtime.environment` | `production` | `TRUSSIUM_ENVIRONMENT`. |
 | `runtime.host` | `0.0.0.0` | Runtime bind host. |
 | `runtime.port` | `9000` | Container and runtime port. |

--- a/docs/INGRESS.md
+++ b/docs/INGRESS.md
@@ -1,0 +1,42 @@
+# Ingress evaluation
+
+The chart does not render an Ingress today. Ingress resources depend on a
+cluster's controller, class, hostname, authentication gateway, and certificate
+management policy. A default chart Ingress could expose the runtime or conflict
+with an existing routing layer.
+
+## Routing contract
+
+| Field | Contract |
+| --- | --- |
+| Backend | Chart-owned `trussium` Service |
+| Backend port | Service port name `http` (9000 by default) |
+| Runtime paths | `/` and the runtime's HTTP API paths, including `/health/*` and `/metrics` when enabled |
+| Controller | Operator-selected `IngressClass` and controller implementation |
+| Hostnames | Operator-owned DNS names and routing policy |
+| TLS | Existing Secret or organization-owned certificate automation |
+
+The runtime does not require an Ingress for in-cluster use. A ClusterIP Service
+and port-forward remain the default access paths. External exposure should be
+introduced only after authentication, rate limiting, request-size limits,
+timeouts, and observability requirements are defined.
+
+## Minimum contract for a future opt-in resource
+
+A future chart option must be disabled by default and require explicit:
+
+- `ingressClassName`, hostnames, and paths;
+- an existing TLS Secret reference, without rendering certificate material;
+- controller-specific annotations supplied by the operator;
+- whether health and metrics paths are exposed externally.
+
+The option must render `networking.k8s.io/v1` only, target the named `http`
+Service port, and include tests for disabled, HTTP, and TLS configurations. It
+must not install an ingress controller, Certificate or Issuer resources,
+authentication gateway, DNS record, or public load balancer.
+
+## Current recommendation
+
+Use an organization-owned Ingress in the platform repository, fronted by the
+approved controller and authentication layer. Keep `/health/*` and `/metrics`
+internal unless the platform explicitly needs external access.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -146,7 +146,10 @@ runbooks, and validation across supported Kubernetes minor versions.
   rendering a Prometheus Operator custom resource.
 - Optional ServiceMonitor after observability endpoints stabilize and operator
   selector requirements are agreed.
-- Optional Ingress integration without owning certificate issuance.
+- [x] Evaluate Ingress routing and certificate ownership without rendering an
+  externally exposing resource.
+- Optional Ingress integration after controller, authentication, and TLS
+  contracts are agreed without owning certificate issuance.
 
 ## Boundary
 

--- a/docs/adr/0004-ingress-ownership.md
+++ b/docs/adr/0004-ingress-ownership.md
@@ -1,0 +1,24 @@
+# ADR 0004: Defer chart-owned Ingress
+
+- Status: Accepted
+- Date: 2026-08-27
+
+## Context
+
+Ingress is implemented by cluster-specific controllers and is commonly coupled
+to DNS, TLS automation, authentication, and public exposure policy. The chart
+cannot safely infer those choices.
+
+## Decision
+
+Do not render an Ingress in the chart yet. Document the Service routing contract
+and require any future resource to be explicitly opt-in with operator-provided
+class, host, path, and existing TLS Secret settings.
+
+## Consequences
+
+- Default installations remain internal and are not exposed accidentally.
+- Platform teams can compose their approved ingress and authentication stack
+  around the stable Service today.
+- A future chart option must avoid owning certificate issuance, DNS, controllers,
+  authentication, or public load-balancer lifecycle.


### PR DESCRIPTION
Closes #59

## Summary

Evaluate optional Ingress integration while keeping certificate issuance and
controller ownership outside the chart.

## Changes

- Document the Service backend, named port, runtime paths, host, and TLS
  contract.
- Define future opt-in Ingress requirements and exposure safeguards.
- Record ADR 0004 deferring chart-owned Ingress resources.
- Update root/chart README documentation and roadmap.
- Preserve the default internal ClusterIP deployment behavior.

## Validation

- `scripts/helm-validate.sh`
- `scripts/chart-contract-test.sh`
- `scripts/chart-package.sh`
- `git diff --check`

## Compatibility

Documentation-only change; no resources or deployment behavior change.
