### PR TITLE
docs: reconcile integration ownership policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The repository is named `trussium-helm`; the chart is named `trussium`. It
 deploys and configures the runtime only. It does **not** install or manage the
 future `trussium-operator`.
 
+Optional platform integrations remain organization-owned by default; see the
+roadmap and ADRs for the criteria required before a chart opt-in is introduced.
+
 ## What the chart installs
 
 - A hardened, autoscaled Trussium Deployment.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -103,9 +103,10 @@ Kubernetes contract into an independently released distribution:
   probes, without chart-owned declarations, resources, permissions, CRDs, or
   operator behavior.
 
-The immediate focus is runtime compatibility operations: automated runtime
-version proposals, an explicit compatibility matrix, release recovery
-runbooks, and validation across supported Kubernetes minor versions.
+The immediate focus is optional platform integration contracts and their
+organization-owned composition. Chart opt-ins will be considered only after a
+stable contract, explicit values, disabled defaults, render tests, and live
+validation are available.
 
 ## Milestone 1 — Repository and chart foundation
 
@@ -121,7 +122,7 @@ runbooks, and validation across supported Kubernetes minor versions.
 
 ## Milestone 2 — Runtime compatibility operations
 
-**Status:** In Progress
+**Status:** Completed
 
 - [x] Automate review-only proposals for newly released compatible runtime
   versions.
@@ -132,6 +133,10 @@ runbooks, and validation across supported Kubernetes minor versions.
 ## Milestone 3 — Optional platform integrations
 
 **Status:** In Progress
+
+Integration policy: NetworkPolicy, ServiceMonitor, and Ingress remain
+organization-owned by default. A future chart opt-in must satisfy ADR 0005's
+contract, safety, and validation requirements.
 
 - [x] Configurable HorizontalPodAutoscaler support after runtime metrics exist.
 - [x] Configurable OpenTelemetry runtime tracing after instrumentation exists.

--- a/docs/adr/0005-optional-integration-ownership.md
+++ b/docs/adr/0005-optional-integration-ownership.md
@@ -1,0 +1,25 @@
+# ADR 0005: Organization-owned optional platform integrations
+
+- Status: Accepted
+- Date: 2026-08-27
+
+## Context
+
+NetworkPolicy, ServiceMonitor, and Ingress depend on cluster-specific network,
+Prometheus Operator, routing, authentication, DNS, and certificate choices.
+The chart has evaluated each contract without rendering those resources.
+
+## Decision
+
+Keep these integrations organization-owned by default. A chart opt-in is only
+appropriate when the contract is stable, values are explicit, the default is
+disabled, render tests cover enabled and disabled modes, and live validation is
+available for any controller or CRD dependency.
+
+## Consequences
+
+- The runtime chart remains portable across Kubernetes distributions.
+- Platform teams retain control of exposure, scraping, network restrictions,
+  authentication, and certificate lifecycle.
+- Future opt-ins must justify their dependency and operational ownership in a
+  separate design and compatibility review.


### PR DESCRIPTION
Closes #61

## Summary

Reconcile roadmap status and establish the ownership policy for optional
platform integrations.

## Changes

- Mark runtime compatibility operations complete.
- Define organization-owned defaults for NetworkPolicy, ServiceMonitor, and
  Ingress.
- Add ADR 0005 with criteria for future chart opt-ins.
- Update roadmap focus and README guidance.

## Validation

- `scripts/helm-validate.sh`
- `scripts/chart-contract-test.sh`
- `scripts/chart-package.sh`
- `git diff --check`

## Compatibility

Documentation-only change; chart templates and deployment behavior are
unchanged.
