### PR TITLE
feat: add opt-in ServiceMonitor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ roadmap and ADRs for the criteria required before a chart opt-in is introduced.
   behavior.
 
 No Namespace, provider credentials, registry credentials, Ingress, Grafana,
-Prometheus, Loki, Tempo, collector, log agent, dashboard, alert, monitoring
-custom resource, or operator resource is created.
+Prometheus, Loki, Tempo, collector, log agent, dashboard, alert, or operator
+resource is created by default. ServiceMonitor is available only as an explicit
+opt-in and requires a Prometheus Operator installation.
 
 ## Prerequisites
 

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -40,6 +40,13 @@ default compatible runtime image.
 | `readiness.dependencyCacheSeconds` | `10` | Positive success and failure cache window. |
 | `readiness.requiredModel` | `""` | Exact model to require; empty lists provider models. |
 | `observability.metrics.enabled` | `true` | Expose runtime metrics at `/metrics`. |
+| `observability.serviceMonitor.enabled` | `false` | Optionally create a Prometheus Operator ServiceMonitor. |
+| `observability.serviceMonitor.namespace` | `""` | Optional ServiceMonitor namespace. |
+| `observability.serviceMonitor.labels` | `{}` | Labels for the Prometheus selector. |
+| `observability.serviceMonitor.annotations` | `{}` | ServiceMonitor annotations. |
+| `observability.serviceMonitor.interval` | `30s` | Prometheus scrape interval. |
+| `observability.serviceMonitor.scrapeTimeout` | `10s` | Prometheus scrape timeout. |
+| `observability.serviceMonitor.path` | `/metrics` | Metrics endpoint path. |
 | `observability.tracing.enabled` | `false` | Enable runtime OpenTelemetry tracing and OTLP export. |
 | `observability.tracing.serviceName` | `trussium` | OpenTelemetry `service.name`. |
 | `observability.tracing.sampleRatio` | `1.0` | Parent-based root sampling probability from zero through one. |
@@ -89,10 +96,11 @@ replicaCount: 3
 ```
 
 Runtime metrics remain independently configurable through
-`observability.metrics.enabled`. The chart does not install Prometheus,
-Prometheus Adapter, ServiceMonitor, or other monitoring resources.
-See the repository's [ServiceMonitor evaluation](../../docs/SERVICEMONITOR.md)
-for the scraping contract and future opt-in requirements.
+`observability.metrics.enabled`. The chart does not install Prometheus or
+Prometheus Adapter. ServiceMonitor is available only when explicitly enabled
+and requires the Prometheus Operator CRD and controller. See the repository's
+[ServiceMonitor evaluation](../../docs/SERVICEMONITOR.md) for the scraping
+contract and opt-in requirements.
 
 ## Dependency-aware readiness
 

--- a/charts/trussium/templates/servicemonitor.yaml
+++ b/charts/trussium/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.observability.metrics.enabled .Values.observability.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "trussium.fullname" . }}
+  {{- with .Values.observability.serviceMonitor.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
+  labels:
+    {{- include "trussium.labels" $ | nindent 4 }}
+    {{- with .Values.observability.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.observability.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "trussium.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.observability.serviceMonitor.path | quote }}
+      interval: {{ .Values.observability.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.observability.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}

--- a/charts/trussium/values.schema.json
+++ b/charts/trussium/values.schema.json
@@ -125,7 +125,7 @@
     "observability": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["metrics", "tracing"],
+      "required": ["metrics", "serviceMonitor", "tracing"],
       "properties": {
         "metrics": {
           "type": "object",
@@ -133,6 +133,20 @@
           "required": ["enabled"],
           "properties": {
             "enabled": {"type": "boolean"}
+          }
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabled", "namespace", "labels", "annotations", "interval", "scrapeTimeout", "path"],
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "namespace": {"type": "string"},
+            "labels": {"type": "object", "additionalProperties": {"type": "string"}},
+            "annotations": {"type": "object", "additionalProperties": {"type": "string"}},
+            "interval": {"type": "string", "pattern": "^[1-9][0-9]*(ms|s|m|h)$"},
+            "scrapeTimeout": {"type": "string", "pattern": "^[1-9][0-9]*(ms|s|m|h)$"},
+            "path": {"type": "string", "pattern": "^/[^\\s]*$"}
           }
         },
         "tracing": {

--- a/charts/trussium/values.yaml
+++ b/charts/trussium/values.yaml
@@ -59,6 +59,14 @@ readiness:
 observability:
   metrics:
     enabled: true
+  serviceMonitor:
+    enabled: false
+    namespace: ""
+    labels: {}
+    annotations: {}
+    interval: 30s
+    scrapeTimeout: 10s
+    path: /metrics
   tracing:
     enabled: false
     serviceName: trussium

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -147,10 +147,9 @@ contract, safety, and validation requirements.
 - [x] Evaluate NetworkPolicy traffic and ownership contracts without rendering
   a potentially unsafe default policy.
 - Optional NetworkPolicy after supported network contracts are defined.
-- [x] Evaluate the ServiceMonitor scraping and ownership contract without
-  rendering a Prometheus Operator custom resource.
-- Optional ServiceMonitor after observability endpoints stabilize and operator
-  selector requirements are agreed.
+- [x] Evaluate the ServiceMonitor scraping and ownership contract.
+- [x] Add a disabled-by-default ServiceMonitor opt-in with explicit selectors
+  and scrape settings; keep the Prometheus Operator organization-owned.
 - [x] Evaluate Ingress routing and certificate ownership without rendering an
   externally exposing resource.
 - Optional Ingress integration after controller, authentication, and TLS

--- a/docs/SERVICEMONITOR.md
+++ b/docs/SERVICEMONITOR.md
@@ -1,9 +1,8 @@
 # ServiceMonitor evaluation
 
-The chart exposes runtime metrics but does not render a `ServiceMonitor`. A
-ServiceMonitor is a Prometheus Operator custom resource, so rendering one
-without confirming that the CRD and controller exist would make otherwise
-valid Helm installs fail or leave a misleading, unscheduled object.
+The chart exposes runtime metrics and can optionally render a `ServiceMonitor`.
+The option is disabled by default because ServiceMonitor is a Prometheus
+Operator custom resource; enabling it requires the CRD and controller to exist.
 
 ## Scraping contract
 
@@ -20,20 +19,20 @@ Kubernetes resource metrics and does not require Prometheus.
 
 ## Minimum contract for a future opt-in resource
 
-A future chart option must be disabled by default and require an installed
-Prometheus Operator. Operators must be able to provide the ServiceMonitor
+A chart option is disabled by default and requires an installed Prometheus
+Operator. Operators can provide the ServiceMonitor
 namespace, labels used by their Prometheus selector, scrape interval, timeout,
 and optional TLS or authorization settings. The chart must not guess those
 values or create Prometheus, RBAC, dashboards, alerts, or monitoring backends.
 
-The option must render only when metrics are enabled and must include contract
+The option renders only when metrics are enabled and includes contract
 tests for disabled, default opt-in, and custom-selector modes. Kind validation
 should remain provider-free and should not assume a Prometheus Operator is
 installed.
 
 ## Current recommendation
 
-Use an organization-owned ServiceMonitor in the platform repository when the
-Prometheus Operator is available. Select the chart Service by its stable
-`app.kubernetes.io/name: trussium` and `app.kubernetes.io/instance` labels,
-target port `http`, and path `/metrics`.
+Enable the chart option when the Prometheus Operator and its selector policy are
+known. Select the chart Service by its stable `app.kubernetes.io/name:
+trussium` and `app.kubernetes.io/instance` labels, target port `http`, and path
+`/metrics`.

--- a/docs/adr/0003-servicemonitor-ownership.md
+++ b/docs/adr/0003-servicemonitor-ownership.md
@@ -1,6 +1,6 @@
 # ADR 0003: Defer chart-owned ServiceMonitor
 
-- Status: Accepted
+- Status: Superseded by ADR 0006
 - Date: 2026-08-27
 
 ## Context

--- a/docs/adr/0006-opt-in-servicemonitor.md
+++ b/docs/adr/0006-opt-in-servicemonitor.md
@@ -1,0 +1,25 @@
+# ADR 0006: Provide an opt-in ServiceMonitor
+
+- Status: Accepted
+- Date: 2026-08-27
+
+## Context
+
+The chart has a stable Prometheus-compatible metrics endpoint and named
+Service port. Operators requested a convenient ServiceMonitor, but clusters
+vary in Prometheus Operator installation and selector policy.
+
+## Decision
+
+Render `monitoring.coreos.com/v1` ServiceMonitor only when both
+`observability.metrics.enabled` and `observability.serviceMonitor.enabled` are
+true. Expose explicit namespace, labels, annotations, interval, timeout, and
+path values; keep the option disabled by default and do not install the CRD or
+controller.
+
+## Consequences
+
+- Existing installations and non-Prometheus clusters are unchanged.
+- Operators can opt in without maintaining a duplicate resource.
+- The Prometheus Operator remains a prerequisite and its lifecycle remains
+  organization-owned.

--- a/scripts/chart-contract-test.sh
+++ b/scripts/chart-contract-test.sh
@@ -7,10 +7,11 @@ chart="$repository_root/charts/trussium"
 custom_values="$repository_root/tests/fixtures/custom-values.yaml"
 default_render="$(mktemp)"
 custom_render="$(mktemp)"
+service_monitor_render="$(mktemp)"
 error_output="$(mktemp)"
 
 cleanup() {
-    rm -f "$default_render" "$custom_render" "$error_output"
+    rm -f "$default_render" "$custom_render" "$service_monitor_render" "$error_output"
 }
 trap cleanup EXIT INT TERM
 
@@ -58,7 +59,14 @@ helm lint --strict "$chart"
 helm lint --strict "$chart" --values "$custom_values"
 helm template trussium "$chart" --namespace trussium-system >"$default_render"
 helm template trussium "$chart" --namespace trussium-custom \
-    --values "$custom_values" >"$custom_render"
+    --values "$custom_values" \
+    --set observability.serviceMonitor.enabled=true >"$custom_render"
+helm template trussium "$chart" --namespace trussium-monitoring \
+    --set observability.serviceMonitor.enabled=true \
+    --set observability.serviceMonitor.namespace=monitoring \
+    --set observability.serviceMonitor.labels.team=platform \
+    --set observability.serviceMonitor.interval=15s \
+    --set observability.serviceMonitor.scrapeTimeout=5s >"$service_monitor_render"
 
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .metadata.name' "$default_render")" \
     "trussium" "default deployment name"
@@ -111,6 +119,18 @@ assert_equal "$(yq -r 'select(.kind == "ConfigMap") | .data.TRUSSIUM_READINESS__
     "true" "custom readiness enablement"
 assert_equal "$(yq -r 'select(.kind == "ConfigMap") | .data.TRUSSIUM_OBSERVABILITY__TRACING_ENABLED' "$custom_render")" \
     "true" "custom tracing enablement"
+assert_equal "$(yq -r 'select(.kind == "ServiceMonitor") | .metadata.namespace' "$service_monitor_render")" \
+    "monitoring" "ServiceMonitor namespace"
+assert_equal "$(yq -r 'select(.kind == "ServiceMonitor") | .spec.selector.matchLabels["app.kubernetes.io/instance"]' "$service_monitor_render")" \
+    "trussium" "ServiceMonitor instance selector"
+assert_equal "$(yq -r 'select(.kind == "ServiceMonitor") | .spec.endpoints[0].port' "$service_monitor_render")" \
+    "http" "ServiceMonitor port"
+assert_equal "$(yq -r 'select(.kind == "ServiceMonitor") | .spec.endpoints[0].path' "$service_monitor_render")" \
+    "/metrics" "ServiceMonitor path"
+assert_equal "$(yq -r 'select(.kind == "ServiceMonitor") | .spec.endpoints[0].interval' "$service_monitor_render")" \
+    "15s" "ServiceMonitor interval"
+assert_equal "$(yq -r 'select(.kind == "ServiceMonitor") | .metadata.labels.team' "$service_monitor_render")" \
+    "platform" "ServiceMonitor custom label"
 
 assert_not_contains "kind: Secret" "$default_render" "default credential rendering"
 assert_not_contains "API_KEY" "$default_render" "credential key rendering"
@@ -119,6 +139,7 @@ assert_not_contains "loki" "$default_render" "Loki rendering"
 assert_not_contains "tempo" "$default_render" "Tempo rendering"
 assert_not_contains "alertmanager" "$default_render" "Alertmanager rendering"
 assert_not_contains "ServiceMonitor" "$default_render" "ServiceMonitor rendering"
+assert_not_contains "ServiceMonitor" "$custom_render" "metrics-disabled ServiceMonitor rendering"
 assert_not_contains "PrometheusRule" "$default_render" "PrometheusRule rendering"
 
 expect_template_failure "replicaCount schema" --set replicaCount=0


### PR DESCRIPTION
Closes #63

## Summary

Add disabled-by-default, explicitly configured ServiceMonitor support for
Prometheus Operator deployments.

## Changes

- Add `observability.serviceMonitor` values and strict schema validation.
- Render `monitoring.coreos.com/v1` only when metrics and ServiceMonitor are
  both enabled.
- Support explicit namespace, labels, annotations, interval, timeout, and path.
- Add contract tests for enabled and metrics-disabled behavior.
- Update chart docs, roadmap, and ADR 0006; supersede the evaluation-only ADR.

## Validation

- `helm lint --strict charts/trussium`
- `scripts/chart-contract-test.sh`
- `scripts/helm-validate.sh`
- `scripts/chart-package.sh`
- `git diff --check`

## Compatibility

The default remains unchanged and does not render a ServiceMonitor. Prometheus
Operator CRDs and controllers remain organization-owned prerequisites.
