### PR TITLE
feat: add opt-in NetworkPolicy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ roadmap and ADRs for the criteria required before a chart opt-in is introduced.
 - A PodDisruptionBudget and topology-spread constraints.
 - An `autoscaling/v2` HorizontalPodAutoscaler with conservative production
   behavior.
+- Optional, explicitly configured NetworkPolicy for ingress and egress control.
 
 No Namespace, provider credentials, registry credentials, Ingress, Grafana,
 Prometheus, Loki, Tempo, collector, log agent, dashboard, alert, or operator
-resource is created by default. ServiceMonitor is available only as an explicit
-opt-in and requires a Prometheus Operator installation.
+resource is created by default. NetworkPolicy and ServiceMonitor are available
+only as explicit opt-ins; ServiceMonitor additionally requires a Prometheus
+Operator installation.
 
 ## Prerequisites
 

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -59,6 +59,12 @@ default compatible runtime image.
 | `autoscaling.behavior` | production defaults | Scale velocity and stabilization rules. |
 | `providerSecret.name` | `trussium-provider` | Existing provider Secret; empty disables it. |
 | `providerSecret.optional` | `true` | Allow startup when that Secret is absent. |
+| `networkPolicy.enabled` | `false` | Optionally render an explicit ingress/egress NetworkPolicy. |
+| `networkPolicy.ingress.from` | `[]` | Ingress peers; empty when enabled denies ingress peers. |
+| `networkPolicy.ingress.ports` | `[{port: 9000, protocol: TCP}]` | Allowed runtime ingress ports. |
+| `networkPolicy.egress.to` | `[]` | Provider/collector egress peers. |
+| `networkPolicy.egress.ports` | `[]` | Provider/collector egress ports. |
+| `networkPolicy.egress.dns.to` | `[]` | Cluster DNS peers for UDP/TCP port 53. |
 | `extraConfig` | `{}` | Additional non-secret ConfigMap entries. |
 | `extraEnv` | `[]` | Additional container environment entries. |
 | `extraEnvFrom` | `[]` | Additional container environment sources. |

--- a/charts/trussium/templates/networkpolicy.yaml
+++ b/charts/trussium/templates/networkpolicy.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "trussium.fullname" . }}
+  labels:
+    {{- include "trussium.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "trussium.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        {{- toYaml .Values.networkPolicy.ingress.ports | nindent 8 }}
+      {{- with .Values.networkPolicy.ingress.from }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.networkPolicy.egress.to }}
+  egress:
+    - ports:
+        {{- toYaml $.Values.networkPolicy.egress.ports | nindent 8 }}
+      to:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.networkPolicy.egress.dns.to }}
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/charts/trussium/values.schema.json
+++ b/charts/trussium/values.schema.json
@@ -18,6 +18,7 @@
     "observability",
     "autoscaling",
     "providerSecret",
+    "networkPolicy",
     "startupProbe",
     "livenessProbe",
     "readinessProbe",
@@ -223,6 +224,40 @@
         "optional": {"type": "boolean"}
       }
     },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "ingress", "egress"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["from", "ports"],
+          "properties": {
+            "from": {"type": "array", "items": {"type": "object"}},
+            "ports": {"type": "array", "items": {"$ref": "#/definitions/networkPort"}}
+          }
+        },
+        "egress": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["to", "ports", "dns"],
+          "properties": {
+            "to": {"type": "array", "items": {"type": "object"}},
+            "ports": {"type": "array", "items": {"$ref": "#/definitions/networkPort"}},
+            "dns": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["to"],
+              "properties": {
+                "to": {"type": "array", "items": {"type": "object"}}
+              }
+            }
+          }
+        }
+      }
+    },
     "extraConfig": {"type": "object", "additionalProperties": {"type": ["string", "number", "boolean"]}},
     "extraEnv": {"type": "array", "items": {"type": "object"}},
     "extraEnvFrom": {"type": "array", "items": {"type": "object"}},
@@ -313,6 +348,15 @@
         "periodSeconds": {"type": "integer", "minimum": 1},
         "timeoutSeconds": {"type": "integer", "minimum": 1},
         "failureThreshold": {"type": "integer", "minimum": 1}
+      }
+    },
+    "networkPort": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["port", "protocol"],
+      "properties": {
+        "port": {"type": ["integer", "string"]},
+        "protocol": {"type": "string", "enum": ["TCP", "UDP", "SCTP"]}
       }
     }
   }

--- a/charts/trussium/values.yaml
+++ b/charts/trussium/values.yaml
@@ -105,6 +105,19 @@ providerSecret:
   name: trussium-provider
   optional: true
 
+networkPolicy:
+  enabled: false
+  ingress:
+    from: []
+    ports:
+      - port: 9000
+        protocol: TCP
+  egress:
+    to: []
+    ports: []
+    dns:
+      to: []
+
 extraConfig: {}
 extraEnv: []
 extraEnvFrom: []

--- a/docs/NETWORK_POLICY.md
+++ b/docs/NETWORK_POLICY.md
@@ -1,8 +1,8 @@
 # NetworkPolicy evaluation
 
-The chart does not render a NetworkPolicy today. This is intentional: the
-runtime's network destinations are deployment-specific and a restrictive,
-chart-owned policy could make a valid installation unavailable.
+The chart can optionally render a NetworkPolicy, disabled by default. The
+runtime's network destinations are deployment-specific, so enabling the policy
+requires explicit ingress peers and egress destinations.
 
 ## Traffic contract
 
@@ -21,7 +21,7 @@ remain outside the chart's ownership boundary.
 
 ## Minimum contract for a future opt-in policy
 
-A future policy must be disabled by default and must let operators explicitly
+A policy is disabled by default and lets operators explicitly
 provide:
 
 - allowed ingress namespace and pod selectors;
@@ -29,14 +29,14 @@ provide:
 - the cluster DNS namespace/pod selector and port 53 UDP/TCP;
 - an explicit metrics-scraper selector, if metrics ingress is restricted.
 
-It must render only `networking.k8s.io/v1`, preserve the runtime Service and
+It renders only `networking.k8s.io/v1`, preserves the runtime Service and
 probe paths, and include contract tests for disabled, ingress-only, and
 fully-configured modes. It must not silently add `0.0.0.0/0` egress as a
 security policy disguised as a default.
 
 ## Current recommendation
 
-Keep NetworkPolicy organization-owned until those selectors and destinations
-are known. Teams that require a deny-by-default posture can apply a policy in
-their platform repository, using the traffic table above and validating it
-against their provider and observability topology.
+Enable the chart policy only when those selectors and destinations are known.
+Teams with more complex requirements can still apply organization-owned
+policies in their platform repository, using the traffic table above and
+validating them against their provider and observability topology.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -144,9 +144,9 @@ contract, safety, and validation requirements.
   dashboard or backend resources.
 - [x] Portable runtime alerting compatibility guidance without chart-owned
   rules, notification routing, or backend resources.
-- [x] Evaluate NetworkPolicy traffic and ownership contracts without rendering
-  a potentially unsafe default policy.
-- Optional NetworkPolicy after supported network contracts are defined.
+- [x] Evaluate NetworkPolicy traffic and ownership contracts.
+- [x] Add a disabled-by-default NetworkPolicy opt-in with explicit peers and
+  egress destinations; keep CNI enforcement organization-owned.
 - [x] Evaluate the ServiceMonitor scraping and ownership contract.
 - [x] Add a disabled-by-default ServiceMonitor opt-in with explicit selectors
   and scrape settings; keep the Prometheus Operator organization-owned.

--- a/docs/adr/0002-network-policy-ownership.md
+++ b/docs/adr/0002-network-policy-ownership.md
@@ -1,6 +1,6 @@
 # ADR 0002: Defer chart-owned NetworkPolicy
 
-- Status: Accepted
+- Status: Superseded by ADR 0007
 - Date: 2026-08-27
 
 ## Context

--- a/docs/adr/0007-opt-in-networkpolicy.md
+++ b/docs/adr/0007-opt-in-networkpolicy.md
@@ -1,0 +1,23 @@
+# ADR 0007: Provide an opt-in NetworkPolicy
+
+- Status: Accepted
+- Date: 2026-08-27
+
+## Context
+
+Network destinations and ingress peers are deployment-specific, but a stable
+policy shape can still support explicit operator configuration.
+
+## Decision
+
+Render `networking.k8s.io/v1` NetworkPolicy only when
+`networkPolicy.enabled` is true. Require operators to provide ingress peers,
+provider/collector egress peers and ports, and DNS peers as needed. Keep the
+default disabled and do not guess CIDRs, selectors, or CNI behavior.
+
+## Consequences
+
+- Existing installations remain unchanged.
+- Enabling the option can intentionally create deny-by-default behavior when
+  peers are omitted, so operators must configure and test it carefully.
+- Provider, DNS, CNI, and cluster policy ownership remains with operators.

--- a/scripts/chart-contract-test.sh
+++ b/scripts/chart-contract-test.sh
@@ -5,13 +5,15 @@ set -eu
 repository_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 chart="$repository_root/charts/trussium"
 custom_values="$repository_root/tests/fixtures/custom-values.yaml"
+network_policy_values="$repository_root/tests/fixtures/network-policy-values.yaml"
 default_render="$(mktemp)"
 custom_render="$(mktemp)"
 service_monitor_render="$(mktemp)"
+network_policy_render="$(mktemp)"
 error_output="$(mktemp)"
 
 cleanup() {
-    rm -f "$default_render" "$custom_render" "$service_monitor_render" "$error_output"
+    rm -f "$default_render" "$custom_render" "$service_monitor_render" "$network_policy_render" "$error_output"
 }
 trap cleanup EXIT INT TERM
 
@@ -67,6 +69,9 @@ helm template trussium "$chart" --namespace trussium-monitoring \
     --set observability.serviceMonitor.labels.team=platform \
     --set observability.serviceMonitor.interval=15s \
     --set observability.serviceMonitor.scrapeTimeout=5s >"$service_monitor_render"
+helm lint --strict "$chart" --values "$network_policy_values"
+helm template trussium "$chart" --namespace trussium-network \
+    --values "$network_policy_values" >"$network_policy_render"
 
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .metadata.name' "$default_render")" \
     "trussium" "default deployment name"
@@ -140,6 +145,15 @@ assert_not_contains "tempo" "$default_render" "Tempo rendering"
 assert_not_contains "alertmanager" "$default_render" "Alertmanager rendering"
 assert_not_contains "ServiceMonitor" "$default_render" "ServiceMonitor rendering"
 assert_not_contains "ServiceMonitor" "$custom_render" "metrics-disabled ServiceMonitor rendering"
+assert_not_contains "NetworkPolicy" "$default_render" "default NetworkPolicy rendering"
+assert_equal "$(yq -r 'select(.kind == "NetworkPolicy") | .spec.policyTypes[0]' "$network_policy_render")" \
+    "Ingress" "NetworkPolicy ingress policy type"
+assert_equal "$(yq -r 'select(.kind == "NetworkPolicy") | .spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]' "$network_policy_render")" \
+    "ingress-nginx" "NetworkPolicy ingress namespace"
+assert_equal "$(yq -r 'select(.kind == "NetworkPolicy") | .spec.egress[0].ports[0].port' "$network_policy_render")" \
+    "443" "NetworkPolicy provider port"
+assert_equal "$(yq -r 'select(.kind == "NetworkPolicy") | .spec.egress[1].ports[0].port' "$network_policy_render")" \
+    "53" "NetworkPolicy DNS port"
 assert_not_contains "PrometheusRule" "$default_render" "PrometheusRule rendering"
 
 expect_template_failure "replicaCount schema" --set replicaCount=0

--- a/tests/fixtures/network-policy-values.yaml
+++ b/tests/fixtures/network-policy-values.yaml
@@ -1,0 +1,25 @@
+networkPolicy:
+  enabled: true
+  ingress:
+    from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: ingress-nginx
+    ports:
+      - port: 9000
+        protocol: TCP
+  egress:
+    to:
+      - ipBlock:
+          cidr: 203.0.113.0/24
+    ports:
+      - port: 443
+        protocol: TCP
+    dns:
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns


### PR DESCRIPTION
Closes #65

## Summary

Add disabled-by-default, explicitly configured NetworkPolicy support.

## Changes

- Add `networkPolicy` values and strict schema validation.
- Render `networking.k8s.io/v1` with explicit ingress, provider/collector
  egress, and DNS rules.
- Keep empty peer lists deny-by-default when the option is intentionally enabled.
- Add contract fixture and assertions for configured and default behavior.
- Update NetworkPolicy docs, roadmap, and ADR 0007; supersede ADR 0002.

## Validation

- `helm lint --strict charts/trussium`
- `scripts/helm-validate.sh`
- `scripts/chart-contract-test.sh`
- `scripts/chart-package.sh`
- `jq empty charts/trussium/values.schema.json`
- `sh -n scripts/chart-contract-test.sh`
- `git diff --check`

## Compatibility

The default remains unchanged and renders no NetworkPolicy. CNI enforcement and
provider/DNS topology remain operator-owned.
