### PR TITLE
feat: add opt-in Ingress support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ roadmap and ADRs for the criteria required before a chart opt-in is introduced.
   behavior.
 - Optional, explicitly configured NetworkPolicy for ingress and egress control.
 
-No Namespace, provider credentials, registry credentials, Ingress, Grafana,
+No Namespace, provider credentials, registry credentials, Grafana,
 Prometheus, Loki, Tempo, collector, log agent, dashboard, alert, or operator
 resource is created by default. NetworkPolicy and ServiceMonitor are available
 only as explicit opt-ins; ServiceMonitor additionally requires a Prometheus

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -27,6 +27,10 @@ default compatible runtime image.
 | `service.type` | `ClusterIP` | Kubernetes Service type. |
 | `service.port` | `9000` | Service port. |
 | `service.annotations` | `{}` | Service annotations. |
+| `ingress.enabled` | `false` | Optionally create a Kubernetes Ingress. |
+| `ingress.className` | `""` | Explicit IngressClass name. |
+| `ingress.hosts` | example host/path | Explicit hosts and paths routed to the runtime. |
+| `ingress.tls` | `[]` | Existing TLS Secret references. |
 | Ingress | not rendered | See the repository's Ingress evaluation before composing external routing. |
 | `runtime.environment` | `production` | `TRUSSIUM_ENVIRONMENT`. |
 | `runtime.host` | `0.0.0.0` | Runtime bind host. |

--- a/charts/trussium/templates/ingress.yaml
+++ b/charts/trussium/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "trussium.fullname" . }}
+  labels:
+    {{- include "trussium.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "trussium.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/trussium/values.schema.json
+++ b/charts/trussium/values.schema.json
@@ -18,6 +18,7 @@
     "observability",
     "autoscaling",
     "providerSecret",
+    "ingress",
     "networkPolicy",
     "startupProbe",
     "livenessProbe",
@@ -253,6 +254,53 @@
               "properties": {
                 "to": {"type": "array", "items": {"type": "object"}}
               }
+            }
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "className", "annotations", "hosts", "tls"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "className": {"type": "string"},
+        "annotations": {"type": "object", "additionalProperties": {"type": "string"}},
+        "hosts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["host", "paths"],
+            "properties": {
+              "host": {"type": "string"},
+              "paths": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["path", "pathType"],
+                  "properties": {
+                    "path": {"type": "string", "pattern": "^/[^\\s]*$"},
+                    "pathType": {"type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"]}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["hosts", "secretName"],
+            "properties": {
+              "hosts": {"type": "array", "items": {"type": "string"}},
+              "secretName": {"type": "string", "minLength": 1}
             }
           }
         }

--- a/charts/trussium/values.yaml
+++ b/charts/trussium/values.yaml
@@ -105,6 +105,17 @@ providerSecret:
   name: trussium-provider
   optional: true
 
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: trussium.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
 networkPolicy:
   enabled: false
   ingress:

--- a/docs/INGRESS.md
+++ b/docs/INGRESS.md
@@ -1,6 +1,6 @@
 # Ingress evaluation
 
-The chart does not render an Ingress today. Ingress resources depend on a
+The chart can optionally render an Ingress, disabled by default. Ingress resources depend on a
 cluster's controller, class, hostname, authentication gateway, and certificate
 management policy. A default chart Ingress could expose the runtime or conflict
 with an existing routing layer.
@@ -23,20 +23,21 @@ timeouts, and observability requirements are defined.
 
 ## Minimum contract for a future opt-in resource
 
-A future chart option must be disabled by default and require explicit:
+The chart option is disabled by default and requires explicit:
 
 - `ingressClassName`, hostnames, and paths;
 - an existing TLS Secret reference, without rendering certificate material;
 - controller-specific annotations supplied by the operator;
 - whether health and metrics paths are exposed externally.
 
-The option must render `networking.k8s.io/v1` only, target the named `http`
+The option renders `networking.k8s.io/v1` only, targets the named `http`
 Service port, and include tests for disabled, HTTP, and TLS configurations. It
 must not install an ingress controller, Certificate or Issuer resources,
 authentication gateway, DNS record, or public load balancer.
 
 ## Current recommendation
 
-Use an organization-owned Ingress in the platform repository, fronted by the
-approved controller and authentication layer. Keep `/health/*` and `/metrics`
-internal unless the platform explicitly needs external access.
+Enable the chart option only when the approved controller and authentication
+layer are known. Keep `/health/*` and `/metrics` internal unless the platform
+explicitly needs external access. Teams with more complex routing can continue
+to use an organization-owned Ingress in their platform repository.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,10 +150,10 @@ contract, safety, and validation requirements.
 - [x] Evaluate the ServiceMonitor scraping and ownership contract.
 - [x] Add a disabled-by-default ServiceMonitor opt-in with explicit selectors
   and scrape settings; keep the Prometheus Operator organization-owned.
-- [x] Evaluate Ingress routing and certificate ownership without rendering an
-  externally exposing resource.
-- Optional Ingress integration after controller, authentication, and TLS
-  contracts are agreed without owning certificate issuance.
+- [x] Evaluate Ingress routing and certificate ownership.
+- [x] Add a disabled-by-default Ingress opt-in with explicit hosts, paths, and
+  existing TLS Secret references; keep controller and certificate lifecycle
+  organization-owned.
 
 ## Boundary
 

--- a/docs/adr/0004-ingress-ownership.md
+++ b/docs/adr/0004-ingress-ownership.md
@@ -1,6 +1,6 @@
 # ADR 0004: Defer chart-owned Ingress
 
-- Status: Accepted
+- Status: Superseded by ADR 0009
 - Date: 2026-08-27
 
 ## Context

--- a/docs/adr/0009-opt-in-ingress.md
+++ b/docs/adr/0009-opt-in-ingress.md
@@ -1,0 +1,22 @@
+# ADR 0009: Provide an opt-in Ingress
+
+- Status: Accepted
+- Date: 2026-08-27
+
+## Context
+
+The chart has a stable Service backend, but Ingress controllers, hostnames,
+authentication, DNS, and TLS automation remain cluster-specific.
+
+## Decision
+
+Render `networking.k8s.io/v1` Ingress only when `ingress.enabled` is true.
+Require explicit class, hosts, paths, annotations, and existing TLS Secret
+references. Do not install controllers, certificates, DNS, authentication, or
+public load balancers.
+
+## Consequences
+
+- Existing internal deployments remain unchanged.
+- Operators can compose approved routing around the chart Service.
+- IngressClass, controller, TLS, and exposure lifecycle remain organization-owned.

--- a/scripts/chart-contract-test.sh
+++ b/scripts/chart-contract-test.sh
@@ -6,14 +6,16 @@ repository_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 chart="$repository_root/charts/trussium"
 custom_values="$repository_root/tests/fixtures/custom-values.yaml"
 network_policy_values="$repository_root/tests/fixtures/network-policy-values.yaml"
+ingress_values="$repository_root/tests/fixtures/ingress-values.yaml"
 default_render="$(mktemp)"
 custom_render="$(mktemp)"
 service_monitor_render="$(mktemp)"
 network_policy_render="$(mktemp)"
+ingress_render="$(mktemp)"
 error_output="$(mktemp)"
 
 cleanup() {
-    rm -f "$default_render" "$custom_render" "$service_monitor_render" "$network_policy_render" "$error_output"
+    rm -f "$default_render" "$custom_render" "$service_monitor_render" "$network_policy_render" "$ingress_render" "$error_output"
 }
 trap cleanup EXIT INT TERM
 
@@ -72,6 +74,9 @@ helm template trussium "$chart" --namespace trussium-monitoring \
 helm lint --strict "$chart" --values "$network_policy_values"
 helm template trussium "$chart" --namespace trussium-network \
     --values "$network_policy_values" >"$network_policy_render"
+helm lint --strict "$chart" --values "$ingress_values"
+helm template trussium "$chart" --namespace trussium-ingress \
+    --values "$ingress_values" >"$ingress_render"
 
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .metadata.name' "$default_render")" \
     "trussium" "default deployment name"
@@ -154,6 +159,17 @@ assert_equal "$(yq -r 'select(.kind == "NetworkPolicy") | .spec.egress[0].ports[
     "443" "NetworkPolicy provider port"
 assert_equal "$(yq -r 'select(.kind == "NetworkPolicy") | .spec.egress[1].ports[0].port' "$network_policy_render")" \
     "53" "NetworkPolicy DNS port"
+assert_not_contains "kind: Ingress" "$default_render" "default Ingress rendering"
+assert_equal "$(yq -r 'select(.kind == "Ingress") | .spec.ingressClassName' "$ingress_render")" \
+    "nginx" "Ingress class"
+assert_equal "$(yq -r 'select(.kind == "Ingress") | .spec.rules[0].host' "$ingress_render")" \
+    "api.example.com" "Ingress host"
+assert_equal "$(yq -r 'select(.kind == "Ingress") | .spec.rules[0].http.paths[0].path' "$ingress_render")" \
+    "/api" "Ingress path"
+assert_equal "$(yq -r 'select(.kind == "Ingress") | .spec.rules[0].http.paths[0].backend.service.port.name' "$ingress_render")" \
+    "http" "Ingress service port"
+assert_equal "$(yq -r 'select(.kind == "Ingress") | .spec.tls[0].secretName' "$ingress_render")" \
+    "trussium-tls" "Ingress TLS Secret"
 assert_not_contains "PrometheusRule" "$default_render" "PrometheusRule rendering"
 
 expect_template_failure "replicaCount schema" --set replicaCount=0

--- a/tests/fixtures/ingress-values.yaml
+++ b/tests/fixtures/ingress-values.yaml
@@ -1,0 +1,14 @@
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+  hosts:
+    - host: api.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+  tls:
+    - hosts:
+        - api.example.com
+      secretName: trussium-tls


### PR DESCRIPTION
Closes #67

## Summary

Add disabled-by-default, explicitly configured Ingress support.

## Changes

- Add ingress values and strict schema validation.
- Render `networking.k8s.io/v1` only when `ingress.enabled` is true.
- Route explicit hosts and paths to the chart Service named `http` port.
- Support explicit class, annotations, and existing TLS Secret references.
- Add contract fixture and assertions for default omission, HTTP routing, and TLS.
- Update docs, roadmap, and ADR 0009; supersede ADR 0004.

## Validation

- `helm lint --strict charts/trussium`
- `scripts/helm-validate.sh`
- `scripts/chart-contract-test.sh`
- `scripts/chart-package.sh`
- `jq empty charts/trussium/values.schema.json`
- `sh -n scripts/chart-contract-test.sh`
- `git diff --check`

## Compatibility

The default remains unchanged and renders no Ingress. Controllers, certificates,
DNS, authentication, and load-balancer lifecycle remain organization-owned.
