### PR TITLE
chore: align chart runtime compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Ingress and certificate ownership are covered in the
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
-| `0.6.x` | `0.67.x` | `>=1.25` |
+| `0.10.x` | `0.98.x` | `>=1.25` |
 | `0.5.x` | `0.41.x` | `>=1.25` |
 | `0.4.9` | `0.40.x` | `>=1.25` |
 | `0.4.8` | `0.39.x` | `>=1.25` |
@@ -481,7 +481,7 @@ scripts/chart-contract-test.sh
 scripts/chart-package.sh
 ```
 
-The complete Kind lifecycle test builds runtime `v0.67.0` from a neighboring
+The complete Kind lifecycle test builds runtime `v0.98.0` from a neighboring
 checkout, installs pinned Metrics Server v0.8.1, and validates install, live
 autoscaling, runtime metrics, tracing configuration, operational startup logs,
 default component health, ordered capability discovery, empty capability

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 0.10.0
-appVersion: "0.67.0"
+appVersion: "0.98.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -8,7 +8,7 @@ records its default runtime target in `charts/trussium/Chart.yaml` under
 
 | Chart release | Default runtime image | Kubernetes |
 | --- | --- | --- |
-| `0.6.x` | `0.67.x` | `>=1.25` |
+| `0.10.x` | `0.98.x` | `>=1.25` |
 | `0.5.x` | `0.41.x` | `>=1.25` |
 | `0.4.9` | `0.40.x` | `>=1.25` |
 | `0.4.8` | `0.39.x` | `>=1.25` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.67.0
+The production Helm chart now carries the validated Trussium v0.98.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.

--- a/scripts/chart-contract-test.sh
+++ b/scripts/chart-contract-test.sh
@@ -89,7 +89,7 @@ assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.secur
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.securityContext.seccompProfile.type' "$default_render")" \
     "RuntimeDefault" "seccomp profile"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].image' "$default_render")" \
-    "ghcr.io/trussiumhq/trussium:0.67.0" "default runtime image"
+    "ghcr.io/trussiumhq/trussium:0.98.0" "default runtime image"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' "$default_render")" \
     "9000" "runtime port"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem' "$default_render")" \

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 3
 image:
-  tag: "0.67.0"
+  tag: "0.98.0"
 runtime:
   capabilityAvailabilityTimeoutSeconds: 0.625
 autoscaling:


### PR DESCRIPTION
Closes #71

## Summary

Align the Helm chart’s documented and tested runtime target with Trussium `0.98.0`.

## Changes

- Update `Chart.yaml` `appVersion` to `0.98.0`.
- Update compatibility matrices, roadmap, README, and fixture image tag.
- Preserve independent chart versioning; semantic release will produce the next chart version on merge.

## Validation

- Helm lint and rendering validation: passed
- Diff validation: passed

The operator remains independently versioned and is not changed by this PR.
