### PR TITLE
chore: enable reviewed major releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ branch = "main"
 tag_format = "v{version}"
 commit_message = "chore(release): {version}"
 allow_zero_version = true
-major_on_zero = false
+major_on_zero = true
 build_command = """
 uv lock
 git add uv.lock


### PR DESCRIPTION
Closes #75

## Summary

Enable semantic-release to calculate a reviewed major version for the Helm chart 0.x line.

## Changes

- Set `major_on_zero = true` in Helm semantic-release configuration.
- Preserve independent chart versioning and publication controls.

## Validation

- Chart CI and release configuration review.