### PR TITLE
feat!: declare stable 1.0.0 Helm chart contract

### DIFF
--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
-version: 0.10.0
-appVersion: "0.98.1"
+version: 1.0.0
+appVersion: "1.0.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -8,7 +8,7 @@ records its default runtime target in `charts/trussium/Chart.yaml` under
 
 | Chart release | Default runtime image | Kubernetes |
 | --- | --- | --- |
-| `0.10.x` | `0.98.x` | `>=1.25` |
+| `1.0.x` | `1.0.x` | `>=1.25` |
 | `0.5.x` | `0.41.x` | `>=1.25` |
 | `0.4.9` | `0.40.x` | `>=1.25` |
 | `0.4.8` | `0.39.x` | `>=1.25` |

--- a/docs/RELEASE_1_0.md
+++ b/docs/RELEASE_1_0.md
@@ -1,0 +1,12 @@
+# Helm chart 1.0 release
+
+The `trussium` chart 1.0.0 is the stable chart contract for deploying the
+Trussium runtime 1.0.0 on Kubernetes 1.25 or newer. The chart remains focused
+on runtime deployment; it does not install `trussium-operator`.
+
+The chart version controls templates, values, schema, and packaging. The
+`appVersion` identifies the default runtime image. Operators may override the
+image tag only after validating that runtime against this chart.
+
+SDKs, provider adapters, and other repositories are independent and optional;
+they are not required to install or operate this chart.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v0.98.1
+The production Helm chart now carries the validated Trussium v1.0.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.
@@ -33,6 +33,8 @@ Kubernetes contract into an independently released distribution:
   with an intentional sampling and retention policy.
 - Schema, render, package, and Kind upgrade/rollback validation for the full
   tracing configuration contract without chart-owned collector resources.
+- Stable 1.0.0 chart metadata targeting the Trussium runtime 1.0.0 image.
+- A documented stable release contract for Kubernetes runtime deployments.
 - Runtime v0.41.0 outbound W3C `traceparent` and optional `tracestate`
   propagation through the existing tracing configuration contract.
 - Explicit runtime privacy boundaries for baggage, request IDs, arbitrary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trussium-helm"
-version = "0.10.0"
+version = "1.0.0"
 description = "Development tooling for the official Trussium Helm chart."
 requires-python = ">=3.12"
 dependencies = []

--- a/scripts/chart-contract-test.sh
+++ b/scripts/chart-contract-test.sh
@@ -89,7 +89,7 @@ assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.secur
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.securityContext.seccompProfile.type' "$default_render")" \
     "RuntimeDefault" "seccomp profile"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].image' "$default_render")" \
-    "ghcr.io/trussiumhq/trussium:0.98.1" "default runtime image"
+    "ghcr.io/trussiumhq/trussium:1.0.0" "default runtime image"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' "$default_render")" \
     "9000" "runtime port"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem' "$default_render")" \

--- a/tests/fixtures/custom-values.yaml
+++ b/tests/fixtures/custom-values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 3
 image:
-  tag: "0.98.1"
+  tag: "1.0.0"
 runtime:
   capabilityAvailabilityTimeoutSeconds: 0.625
 autoscaling:

--- a/uv.lock
+++ b/uv.lock
@@ -482,7 +482,7 @@ wheels = [
 
 [[package]]
 name = "trussium-helm"
-version = "0.10.0"
+version = "1.0.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes #77

## Summary

Declare the stable 1.0.0 contract for the official Trussium Helm chart.

## Changes

- Bump the chart and repository package version to 1.0.0.
- Target the Trussium runtime 1.0.0 image by default.
- Update the compatibility matrix, roadmap, and stable-release documentation.
- Update chart contract fixtures and assertions for the 1.0.0 image.
- Preserve independent chart/runtime versioning and the runtime-only ownership boundary.

## Validation

- `uv lock`
- `scripts/chart-contract-test.sh`
- `scripts/helm-validate.sh`
- `scripts/chart-package.sh`
- `git diff --check`

## Release notes

This is a deliberate breaking-change release trigger for Helm chart 1.0.0.
SDKs and provider adapters remain independent and optional.
