### PR TITLE
feat: align chart with runtime v1.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Ingress and certificate ownership are covered in the
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
-| `0.10.x` | `0.98.x` | `>=1.25` |
+| `1.0.x` | `1.17.x` | `>=1.25` |
 | `0.5.x` | `0.41.x` | `>=1.25` |
 | `0.4.9` | `0.40.x` | `>=1.25` |
 | `0.4.8` | `0.39.x` | `>=1.25` |

--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 1.0.0
-appVersion: "1.0.0"
+appVersion: "1.17.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -8,7 +8,7 @@ records its default runtime target in `charts/trussium/Chart.yaml` under
 
 | Chart release | Default runtime image | Kubernetes |
 | --- | --- | --- |
-| `1.0.x` | `1.0.x` | `>=1.25` |
+| `1.0.x` | `1.17.x` | `>=1.25` |
 | `0.5.x` | `0.41.x` | `>=1.25` |
 | `0.4.9` | `0.40.x` | `>=1.25` |
 | `0.4.8` | `0.39.x` | `>=1.25` |

--- a/docs/RELEASE_1_1.md
+++ b/docs/RELEASE_1_1.md
@@ -1,0 +1,13 @@
+# Helm chart 1.1 release preparation
+
+The next chart release is a compatibility update for runtime `v1.17.0`.
+`appVersion` will target `1.17.0`; the chart version remains independently
+managed and is expected to advance to `v1.1.0` through the normal semantic
+release workflow.
+
+The chart continues to install the Trussium runtime workload only. It does not
+install the Kubernetes Operator. Existing Kubernetes `>=1.25` requirements,
+values, health probes, metrics, and lifecycle contracts remain unchanged.
+
+Before publication, CI must validate rendering, package contents, Kind
+lifecycle behavior, and the default runtime image tag.

--- a/scripts/chart-contract-test.sh
+++ b/scripts/chart-contract-test.sh
@@ -89,7 +89,7 @@ assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.secur
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.securityContext.seccompProfile.type' "$default_render")" \
     "RuntimeDefault" "seccomp profile"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].image' "$default_render")" \
-    "ghcr.io/trussiumhq/trussium:1.0.0" "default runtime image"
+    "ghcr.io/trussiumhq/trussium:1.17.0" "default runtime image"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' "$default_render")" \
     "9000" "runtime port"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem' "$default_render")" \


### PR DESCRIPTION
Closes #398

## Summary
- update the default runtime image and appVersion to 1.17.0
- update chart compatibility documentation and contract assertions
- document chart 1.1 release preparation while preserving independent chart versioning
- keep the chart runtime-only; the Operator remains separate

## Validation
- scripts/chart-contract-test.sh
- git diff --check

## Documentation
- README compatibility matrix updated
- docs/COMPATIBILITY.md updated
- docs/RELEASE_1_1.md added