### PR TITLE
feat: align chart with runtime v1.22.0

### DIFF
--- a/charts/trussium/Chart.yaml
+++ b/charts/trussium/Chart.yaml
@@ -3,7 +3,7 @@ name: trussium
 description: Official Helm chart for deploying the Trussium AI runtime.
 type: application
 version: 1.1.0
-appVersion: "1.17.0"
+appVersion: "1.22.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium
 sources:

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -8,6 +8,7 @@ records its default runtime target in `charts/trussium/Chart.yaml` under
 
 | Chart release | Default runtime image | Kubernetes |
 | --- | --- | --- |
+| `1.2.x` | `1.22.x` | `>=1.25` |
 | `1.0.x` | `1.17.x` | `>=1.25` |
 | `0.5.x` | `0.41.x` | `>=1.25` |
 | `0.4.9` | `0.40.x` | `>=1.25` |

--- a/docs/RELEASE_1_2.md
+++ b/docs/RELEASE_1_2.md
@@ -1,0 +1,12 @@
+# Helm chart 1.2 release preparation
+
+The next chart release updates the default runtime compatibility target to
+`v1.22.0`. The chart version remains independently managed and is expected to
+advance to `v1.2.0` through the normal semantic release workflow.
+
+The chart continues to install the Trussium runtime workload only. It does not
+install the Kubernetes Operator. Existing Kubernetes `>=1.25` requirements,
+values, health probes, metrics, and lifecycle contracts remain unchanged.
+
+Before publication, CI must validate rendering, package contents, Kind
+lifecycle behavior, and the default runtime image tag.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ remains a separate project.
 
 ## Current focus
 
-The production Helm chart now carries the validated Trussium v1.0.0
+The production Helm chart now carries the validated Trussium v1.22.0
 Kubernetes contract into an independently released distribution:
 
 - Hardened autoscaled runtime pods with a two-replica availability floor.

--- a/scripts/chart-contract-test.sh
+++ b/scripts/chart-contract-test.sh
@@ -89,7 +89,7 @@ assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.secur
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.securityContext.seccompProfile.type' "$default_render")" \
     "RuntimeDefault" "seccomp profile"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].image' "$default_render")" \
-    "ghcr.io/trussiumhq/trussium:1.17.0" "default runtime image"
+    "ghcr.io/trussiumhq/trussium:1.22.0" "default runtime image"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' "$default_render")" \
     "9000" "runtime port"
 assert_equal "$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem' "$default_render")" \


### PR DESCRIPTION
Closes #82

## Summary

- align the chart default runtime appVersion to v1.22.0
- update the Helm-native contract test image assertion
- add the 1.2.x / 1.22.x compatibility row
- document the 1.2 release preparation and roadmap baseline

## Validation

- `scripts/helm-validate.sh`
- `scripts/chart-contract-test.sh`
- `scripts/chart-package.sh`
- `git diff --check`
