### PR TITLE
docs: refresh release references and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Ingress and certificate ownership are covered in the
 
 | Chart release | Default runtime | Kubernetes |
 | --- | --- | --- |
+| `1.3.x` | `1.22.x` | `>=1.25` |
+| `1.2.x` | `1.22.x` | `>=1.25` |
 | `1.0.x` | `1.17.x` | `>=1.25` |
 | `0.5.x` | `0.41.x` | `>=1.25` |
 | `0.4.9` | `0.40.x` | `>=1.25` |
@@ -150,7 +152,7 @@ referenced. The chart never accepts or renders credential values.
 
 ## Dependency-aware readiness
 
-Runtime v0.41.0 can make `/health/ready` reflect provider metadata access and,
+Runtime v1.22.0 can make `/health/ready` reflect provider metadata access and,
 optionally, the availability of a required model. The chart keeps these checks
 disabled by default so installs without provider configuration retain the
 existing `{"status":"ok"}` readiness response.
@@ -183,7 +185,7 @@ visible to anyone who can read the ConfigMap, so do not put credentials,
 provider endpoints, or other secrets in these values. The chart never creates
 provider credentials, installs a provider or model server, downloads models,
 or performs inference. See the version-pinned
-[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/HEALTH.md)
+[runtime health guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/HEALTH.md)
 for response reasons, rollout guidance, privacy boundaries, and
 troubleshooting.
 
@@ -259,7 +261,7 @@ choose sampling and retention policies appropriate to the cluster. Do not put
 collector credentials in `extraConfig`; use an organization-managed network
 or secret-based integration outside the chart.
 
-Runtime v0.41.0 propagates W3C `traceparent` and optional `tracestate` from the
+Runtime v1.22.0 propagates W3C `traceparent` and optional `tracestate` from the
 active provider span to supported OpenAI and Ollama-compatible JSON and SSE
 requests. It does not propagate baggage, request IDs, arbitrary inbound
 headers, prompts, completions, bodies, or credentials as tracing metadata. A
@@ -268,7 +270,7 @@ own span; the chart does not install or instrument that receiver. See the
 [runtime tracing guide](https://github.com/trussiumhq/trussium/blob/main/docs/TRACING.md)
 for the complete span, privacy, lifecycle, sampling, and propagation contract.
 
-Runtime v0.41.0 also emits newline-delimited structured operational JSON for
+Runtime v1.22.0 also emits newline-delimited structured operational JSON for
 safe configuration summaries, provider configuration readiness, application
 and server lifecycle, graceful-drain outcomes, invalid configuration, and
 trace-export failures. Provider configuration events describe local setup;
@@ -281,34 +283,34 @@ shipper, storage backend, dashboard, or alert. See the
 [runtime operational logging guide](https://github.com/trussiumhq/trussium/blob/main/docs/OPERATIONAL_LOGGING.md)
 for the stable event and privacy contract.
 
-Runtime v0.41.0 adds a public typed hierarchy for Trussium-owned
+Runtime v1.22.0 adds a public typed hierarchy for Trussium-owned
 configuration, lifecycle, dependency, capability, and provider failures. This
 is an additive application API: it does not change the chart, runtime settings,
 HTTP or SSE error envelopes, cancellation, or Kubernetes behavior. See the
-[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/ERRORS.md)
+[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/ERRORS.md)
 for stable codes, catch boundaries, compatibility, and privacy rules.
 
-Runtime v0.41.0 adds a typed asynchronous lifecycle contract for
+Runtime v1.22.0 adds a typed asynchronous lifecycle contract for
 application-scoped runtime services with declaration-order startup,
 reverse-order shutdown, partial-startup rollback, and bounded per-hook cleanup.
 This is a runtime composition API: the chart does not declare services or
 hooks, add a lifecycle value, or change pod termination behavior. Operators can
 still pass advanced runtime environment settings through the existing
 `extraConfig` map after their own compatibility review. See the version-pinned
-[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/LIFECYCLE.md)
+[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/LIFECYCLE.md)
 for ordering, failure, cancellation, privacy, and extension boundaries.
 
-Runtime v0.41.0 provides a public application-scoped service registry with
+Runtime v1.22.0 provides a public application-scoped service registry with
 explicit insertion-ordered registration, stable optional and required lookup,
 immutable discovery snapshots, duplicate protection, and one-way sealing
 before lifecycle composition. This remains a runtime application API: the
 chart does not declare or discover services, add registry values, load
 plugins, or change lifecycle and pod behavior.
 See the version-pinned
-[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/SERVICE_REGISTRY.md)
+[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/SERVICE_REGISTRY.md)
 for registration, lookup, errors, ownership, privacy, and extension boundaries.
 
-Runtime v0.41.0 lets registered application services opt into bounded component
+Runtime v1.22.0 lets registered application services opt into bounded component
 health reporting. The runtime evaluates checks concurrently under independent
 deadlines, preserves registry order, normalizes failures to stable reason
 codes, emits transition-only structured events, and exposes the informational
@@ -322,10 +324,10 @@ define component checks, health policy, recovery actions, service declarations,
 or a dedicated component-health value. Advanced runtime compositions can pass
 the bounded runtime timeout through the existing `extraConfig` map after their
 own compatibility review. See the version-pinned
-[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/COMPONENT_HEALTH.md)
+[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/COMPONENT_HEALTH.md)
 for status, aggregation, deadline, event, privacy, and extension contracts.
 
-Runtime v0.41.0 adds a provider-neutral application-scoped capability registry
+Runtime v1.22.0 adds a provider-neutral application-scoped capability registry
 with canonical names, explicit insertion-ordered registration, stable lookup,
 immutable discovery snapshots, duplicate protection, safe errors, one-way
 sealing, and application-owned execution composition. This is an additive
@@ -334,52 +336,52 @@ discovery values, expose an endpoint, load plugins, or change Kubernetes
 resources, probes, settings, or provider behavior. The production runtime
 registers configured chat execution internally under `chat.completions`. See
 the version-pinned
-[runtime capability registry guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_REGISTRY.md)
+[runtime capability registry guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_REGISTRY.md)
 for identity, registration, lookup, sealing, ownership, compatibility, error,
 privacy, and extension boundaries.
 
-Runtime v0.41.0 adds frozen, bounded metadata to capability registrations and
+Runtime v1.22.0 adds frozen, bounded metadata to capability registrations and
 an ordered `GET /v1/capabilities` discovery endpoint. Provider-free deployments
 return `{"capabilities":[]}`. The response deliberately excludes provider,
 model, implementation, health, availability, and configuration data. This
 runtime-owned contract adds no chart values, templates, resources, probes, or
 permissions. See the version-pinned
-[runtime capability discovery guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_DISCOVERY.md)
+[runtime capability discovery guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_DISCOVERY.md)
 for response shape, ordering, privacy, compatibility, and ownership boundaries.
 
-Runtime v0.41.0 adds a sealed-registry-backed provider-neutral execution
+Runtime v1.22.0 adds a sealed-registry-backed provider-neutral execution
 pipeline for asynchronous and streaming capability work. It preserves context,
 results, events, native failures, cancellation, and upstream cleanup while the
 existing chat JSON/SSE telemetry and transport contracts remain unchanged. The
 pipeline is runtime-owned and adds no chart value, template, resource, probe,
 permission, endpoint, or configuration. See the version-pinned
-[runtime capability execution pipeline guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_EXECUTION_PIPELINE.md)
+[runtime capability execution pipeline guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_EXECUTION_PIPELINE.md)
 for composition, invocation, cleanup, compatibility, and ownership boundaries.
 
-Runtime v0.41.0 adds ordered provider-neutral capability middleware around the
+Runtime v1.22.0 adds ordered provider-neutral capability middleware around the
 execution pipeline. Application composition can observe immutable invocation
 metadata, continue once, or short-circuit asynchronous and streaming work while
 the runtime preserves context, failures, event identity, and deterministic
 cleanup. Middleware remains runtime-owned and adds no chart value, template,
 resource, probe, permission, endpoint, environment setting, or routing policy.
 See the version-pinned
-[runtime capability middleware guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_MIDDLEWARE.md)
+[runtime capability middleware guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_MIDDLEWARE.md)
 for contracts, ordering, cleanup, compatibility, and ownership boundaries.
 
-Runtime v0.41.0 lets registered capabilities optionally own application-scoped
+Runtime v1.22.0 lets registered capabilities optionally own application-scoped
 resources through ordered asynchronous startup, reverse shutdown,
 partial-startup rollback, bounded cleanup, deterministic state, and safe
 operational failures. Ordinary capabilities remain unchanged. Lifecycle is a
 runtime-owned Python contract and adds no chart value, schema, template,
 resource, probe, permission, endpoint, environment setting, CRD, or operator
 behavior. See the version-pinned
-[runtime capability lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_LIFECYCLE.md)
+[runtime capability lifecycle guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_LIFECYCLE.md)
 for ownership, ordering, cleanup, cancellation, errors, events, privacy, and
 extension boundaries.
 
 ## Capability availability reporting
 
-Runtime v0.41.0 gives every registered capability a bounded informational
+Runtime v1.22.0 gives every registered capability a bounded informational
 availability state. Ordinary registrations default to available; optional
 checks run concurrently under a runtime-owned deadline, preserve registry
 order, normalize failures to stable reasons, and emit transition-only events.
@@ -399,20 +401,20 @@ not gate execution or add routing, retry, fallback, recovery, capability
 declarations, Kubernetes probes, resources, permissions, CRDs, or operator
 behavior. The provider-free chart response is
 `{"status":"available","capabilities":[]}`. See the version-pinned
-[runtime capability availability guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_AVAILABILITY.md)
+[runtime capability availability guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_AVAILABILITY.md)
 for values, aggregation, failures, events, privacy, and extension boundaries.
 
-Runtime v0.41.0 provides three portable Grafana dashboard JSON models in the
+Runtime v1.22.0 provides three portable Grafana dashboard JSON models in the
 runtime repository: a Prometheus overview, a Loki structured-log view, and a
 Tempo trace investigation view. Prometheus is required only for the overview;
 Loki and Tempo remain optional. The chart does not bundle, mount, import, or
 provision those files and does not install Grafana, observability backends,
 collectors, log agents, dashboard custom resources, or alerts. Operators own
 data collection, dashboard import, backend access control, and retention. See
-the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/DASHBOARDS.md)
+the [runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/DASHBOARDS.md)
 for artifacts, import methods, variables, privacy, and troubleshooting.
 
-Runtime v0.41.0 also provides five portable Prometheus starter alerts for
+Runtime v1.22.0 also provides five portable Prometheus starter alerts for
 missing telemetry, elevated request failures, elevated cancellations, high p95
 latency, and process restarts. Their severity, hold times, traffic guards, and
 thresholds are reference values that operators must review against their SLOs,
@@ -423,9 +425,9 @@ load them and does not create a rule ConfigMap, `PrometheusRule`,
 `AlertmanagerConfig`, notification route, silence, or monitoring backend.
 Operators own rule loading, target scoping, threshold tuning, routing,
 inhibition, maintenance windows, access control, and retention. See the
-[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/ALERTING.md)
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/ALERTING.md)
 and the
-[reference rules](https://github.com/trussiumhq/trussium/blob/v0.41.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+[reference rules](https://github.com/trussiumhq/trussium/blob/v1.22.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
 for the complete contract and runbooks.
 
 The complete value reference is in the

--- a/charts/trussium/README.md
+++ b/charts/trussium/README.md
@@ -114,7 +114,7 @@ contract and opt-in requirements.
 
 ## Dependency-aware readiness
 
-Runtime v0.41.0 can include provider metadata access in `/health/ready`. The
+Runtime v1.22.0 can include provider metadata access in `/health/ready`. The
 chart preserves backward-compatible behavior by disabling dependency checks by
 default:
 
@@ -143,7 +143,7 @@ provider availability. The required-model identifier is non-secret ConfigMap
 data visible to anyone who can read that resource; do not place credentials,
 provider endpoints, or other secrets in readiness values. See the
 version-pinned
-[runtime health guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/HEALTH.md)
+[runtime health guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/HEALTH.md)
 for response reasons, rollout guidance, privacy boundaries, and
 troubleshooting.
 
@@ -175,7 +175,7 @@ network and secret controls. The runtime excludes health and metrics traffic
 and does not attach prompts, bodies, credentials, query strings, raw URLs, or
 exception messages to spans.
 
-With runtime v0.41.0, the active provider span is propagated to supported
+With runtime v1.22.0, the active provider span is propagated to supported
 OpenAI and Ollama-compatible JSON and SSE requests as W3C `traceparent` and
 optional `tracestate`. Baggage, request IDs, arbitrary inbound headers,
 payloads, and credentials remain behind the runtime privacy boundary. The
@@ -186,7 +186,7 @@ for the complete contract.
 
 ## Structured operational logs
 
-Runtime v0.41.0 writes bounded newline-delimited JSON events to standard
+Runtime v1.22.0 writes bounded newline-delimited JSON events to standard
 output for startup configuration, provider configuration readiness,
 observability enablement, application and server shutdown, graceful-drain
 timeouts, invalid settings, and trace-export failures.
@@ -207,16 +207,16 @@ for the stable event table and privacy boundary.
 
 ## Runtime exception hierarchy
 
-Runtime v0.41.0 adds public typed bases for Trussium-owned configuration,
+Runtime v1.22.0 adds public typed bases for Trussium-owned configuration,
 lifecycle, dependency, capability, and provider failures. This additive Python
 API changes no chart values, templates, HTTP or SSE envelopes, cancellation,
 or Kubernetes resources. See the version-pinned
-[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/ERRORS.md)
+[runtime exception guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/ERRORS.md)
 for stable codes, catch boundaries, compatibility, and privacy rules.
 
 ## Runtime service lifecycle
 
-Runtime v0.41.0 adds a typed asynchronous lifecycle contract for
+Runtime v1.22.0 adds a typed asynchronous lifecycle contract for
 application-scoped runtime services with declaration-order startup,
 reverse-order shutdown, partial-startup rollback, and bounded per-hook cleanup.
 This is runtime-owned composition behavior. The chart does not declare
@@ -224,24 +224,24 @@ services or hooks, add a dedicated cleanup value, or change pod termination
 behavior. Operators may pass advanced runtime environment settings through the
 existing `extraConfig` map after their own compatibility review. See the
 version-pinned
-[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/LIFECYCLE.md)
+[runtime lifecycle guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/LIFECYCLE.md)
 for ordering, failure, cancellation, privacy, and extension boundaries.
 
 ## Runtime service registry
 
-Runtime v0.41.0 provides a public application-scoped service registry with
+Runtime v1.22.0 provides a public application-scoped service registry with
 explicit insertion-ordered registration, stable optional and required lookup,
 immutable discovery snapshots, duplicate protection, and one-way sealing
 before lifecycle composition. This is runtime-owned composition behavior. The
 chart does not declare or discover services, add registry values, load
 plugins, or change lifecycle and pod behavior.
 See the version-pinned
-[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/SERVICE_REGISTRY.md)
+[runtime service registry guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/SERVICE_REGISTRY.md)
 for registration, lookup, errors, ownership, privacy, and extension boundaries.
 
 ## Runtime component health
 
-Runtime v0.41.0 lets registered application services opt into bounded component
+Runtime v1.22.0 lets registered application services opt into bounded component
 health reporting. The runtime evaluates checks concurrently under independent
 deadlines, preserves registry order, normalizes failures to stable reason
 codes, emits transition-only structured events, and exposes the informational
@@ -255,12 +255,12 @@ define component checks, health policy, recovery actions, service declarations,
 or a dedicated component-health value. Advanced runtime compositions can pass
 the bounded runtime timeout through the existing `extraConfig` map after their
 own compatibility review. See the version-pinned
-[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/COMPONENT_HEALTH.md)
+[runtime component health guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/COMPONENT_HEALTH.md)
 for status, aggregation, deadline, event, privacy, and extension contracts.
 
 ## Core capability registry
 
-Runtime v0.41.0 adds a provider-neutral application-scoped capability registry
+Runtime v1.22.0 adds a provider-neutral application-scoped capability registry
 with canonical names, explicit insertion-ordered registration, stable lookup,
 immutable discovery snapshots, duplicate protection, safe errors, one-way
 sealing, and application-owned execution composition. This is runtime-owned
@@ -269,60 +269,60 @@ discovery values, expose an endpoint, load plugins, or change Kubernetes
 resources, probes, settings, or provider behavior. The production runtime
 registers configured chat execution internally under `chat.completions`. See
 the version-pinned
-[runtime capability registry guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_REGISTRY.md)
+[runtime capability registry guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_REGISTRY.md)
 for identity, registration, lookup, sealing, ownership, compatibility, error,
 privacy, and extension boundaries.
 
 ## Capability metadata and discovery
 
-Runtime v0.41.0 adds frozen, bounded metadata to capability registrations and
+Runtime v1.22.0 adds frozen, bounded metadata to capability registrations and
 an ordered `GET /v1/capabilities` discovery endpoint. Provider-free deployments
 return `{"capabilities":[]}`. The response deliberately excludes provider,
 model, implementation, health, availability, and configuration data. This is a
 runtime-owned contract: the chart adds no values, templates, resources, probes,
 or permissions. See the version-pinned
-[runtime capability discovery guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_DISCOVERY.md)
+[runtime capability discovery guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_DISCOVERY.md)
 for response shape, ordering, privacy, compatibility, and ownership boundaries.
 
 ## Capability execution pipeline
 
-Runtime v0.41.0 adds a sealed-registry-backed provider-neutral execution
+Runtime v1.22.0 adds a sealed-registry-backed provider-neutral execution
 pipeline for asynchronous and streaming capability work. It preserves context,
 results, events, native failures, cancellation, and upstream cleanup while the
 existing chat JSON/SSE telemetry and transport contracts remain unchanged. The
 pipeline is runtime-owned and adds no chart value, template, resource, probe,
 permission, endpoint, or configuration. See the version-pinned
-[runtime capability execution pipeline guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_EXECUTION_PIPELINE.md)
+[runtime capability execution pipeline guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_EXECUTION_PIPELINE.md)
 for composition, invocation, cleanup, compatibility, and ownership boundaries.
 
 ## Capability middleware
 
-Runtime v0.41.0 adds ordered provider-neutral capability middleware around the
+Runtime v1.22.0 adds ordered provider-neutral capability middleware around the
 execution pipeline. Application composition can observe immutable invocation
 metadata, continue once, or short-circuit asynchronous and streaming work while
 the runtime preserves context, failures, event identity, and deterministic
 cleanup. Middleware remains runtime-owned and adds no chart value, template,
 resource, probe, permission, endpoint, environment setting, or routing policy.
 See the version-pinned
-[runtime capability middleware guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_MIDDLEWARE.md)
+[runtime capability middleware guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_MIDDLEWARE.md)
 for contracts, ordering, cleanup, compatibility, and ownership boundaries.
 
 ## Capability lifecycle management
 
-Runtime v0.41.0 lets registered capabilities optionally own application-scoped
+Runtime v1.22.0 lets registered capabilities optionally own application-scoped
 resources through ordered asynchronous startup, reverse shutdown,
 partial-startup rollback, bounded cleanup, deterministic state, and safe
 operational failures. Ordinary capabilities remain unchanged. Lifecycle is a
 runtime-owned Python contract and adds no chart value, schema, template,
 resource, probe, permission, endpoint, environment setting, CRD, or operator
 behavior. See the version-pinned
-[runtime capability lifecycle guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_LIFECYCLE.md)
+[runtime capability lifecycle guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_LIFECYCLE.md)
 for ownership, ordering, cleanup, cancellation, errors, events, privacy, and
 extension boundaries.
 
 ## Capability availability reporting
 
-Runtime v0.41.0 gives every registered capability a bounded informational
+Runtime v1.22.0 gives every registered capability a bounded informational
 availability state. Ordinary registrations default to available; optional
 checks run concurrently under a runtime-owned deadline, preserve registry
 order, normalize failures to stable reasons, and emit transition-only events.
@@ -342,12 +342,12 @@ not gate execution or add routing, retry, fallback, recovery, capability
 declarations, Kubernetes probes, resources, permissions, CRDs, or operator
 behavior. The provider-free chart response is
 `{"status":"available","capabilities":[]}`. See the version-pinned
-[runtime capability availability guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/CAPABILITY_AVAILABILITY.md)
+[runtime capability availability guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/CAPABILITY_AVAILABILITY.md)
 for values, aggregation, failures, events, privacy, and extension boundaries.
 
 ## Portable runtime dashboards
 
-Runtime v0.41.0 provides three independently importable Grafana dashboard JSON
+Runtime v1.22.0 provides three independently importable Grafana dashboard JSON
 models in the runtime repository:
 
 - `Trussium Runtime Overview` uses Prometheus for demand, active work,
@@ -362,12 +362,12 @@ chart does not bundle, mount, import, or provision dashboard JSON and does not
 install Grafana, any observability backend, a collector, log agent, dashboard
 sidecar, custom resource, or alert. Collection, access control, retention, and
 dashboard lifecycle remain operator-owned. See the
-[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/DASHBOARDS.md)
+[runtime dashboard guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/DASHBOARDS.md)
 for import, provisioning, variables, privacy, and troubleshooting.
 
 ## Portable runtime alerts
 
-Runtime v0.41.0 provides five portable Prometheus starter alerts for missing
+Runtime v1.22.0 provides five portable Prometheus starter alerts for missing
 telemetry, elevated request failures, elevated cancellations, high p95 latency,
 and process restarts. The published severities, hold times, traffic guards, and
 thresholds are reference values that operators must tune for their SLOs,
@@ -378,7 +378,7 @@ mount, or load them and does not create a rule ConfigMap, `PrometheusRule`,
 `AlertmanagerConfig`, notification route, silence, or monitoring backend.
 Operators own rule loading, target scoping, threshold tuning, routing,
 inhibition, maintenance windows, access control, and retention. See the
-[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v0.41.0/docs/ALERTING.md)
+[runtime alerting guide](https://github.com/trussiumhq/trussium/blob/v1.22.0/docs/ALERTING.md)
 and the
-[reference rules](https://github.com/trussiumhq/trussium/blob/v0.41.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
+[reference rules](https://github.com/trussiumhq/trussium/blob/v1.22.0/deploy/observability/prometheus/rules/trussium-runtime-alerts.yaml)
 for the complete contract and runbooks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-_Last updated: August 2026_
+_Last updated: September 2026_
 
 This repository owns the independently versioned Helm distribution for the
 Trussium runtime. Runtime code and static Kustomize manifests remain in
@@ -35,69 +35,69 @@ Kubernetes contract into an independently released distribution:
   tracing configuration contract without chart-owned collector resources.
 - Stable 1.0.0 chart metadata targeting the Trussium runtime 1.0.0 image.
 - A documented stable release contract for Kubernetes runtime deployments.
-- Runtime v0.41.0 outbound W3C `traceparent` and optional `tracestate`
+- Runtime v1.22.0 outbound W3C `traceparent` and optional `tracestate`
   propagation through the existing tracing configuration contract.
 - Explicit runtime privacy boundaries for baggage, request IDs, arbitrary
   headers, payloads, and credentials, without chart-owned receiver resources.
-- Runtime v0.41.0 structured operational events for configuration, provider
+- Runtime v1.22.0 structured operational events for configuration, provider
   readiness, lifecycle, graceful drain, and trace-export failures.
 - Default-deployment validation of safe startup events from live pod logs.
 - Explicit operational-log privacy boundaries without chart-owned collectors,
   shippers, storage backends, dashboards, alerts, sidecars, or volumes.
-- Runtime v0.41.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
+- Runtime v1.22.0 portable Prometheus, Loki, and Tempo dashboard artifacts with
   stable identities and selectable operator-owned data sources.
 - Explicit dashboard ownership boundaries without chart-bundled JSON,
   ConfigMaps, sidecars, custom resources, monitoring backends, or alerts.
 - Version-pinned dashboard import, collection, privacy, and troubleshooting
   guidance linked from chart operations documentation.
-- Runtime v0.41.0 portable Prometheus starter alerts and operator runbooks for
+- Runtime v1.22.0 portable Prometheus starter alerts and operator runbooks for
   missing telemetry, request failures, cancellations, latency, and restarts.
 - Explicit alerting ownership boundaries without chart-bundled rules,
   ConfigMaps, `PrometheusRule`, `AlertmanagerConfig`, notification routing, or
   monitoring backends.
 - Version-pinned alert adoption, tuning, routing, lifecycle, privacy, and
   troubleshooting guidance linked from chart operations documentation.
-- Runtime v0.41.0 dependency-aware readiness settings for opt-in provider
+- Runtime v1.22.0 dependency-aware readiness settings for opt-in provider
   metadata and required-model checks, with bounded timeout and cache controls.
 - Backward-compatible disabled defaults, conditional required-model rendering,
   strict value validation, and live install/upgrade/rollback coverage.
 - Version-pinned health, rollout, privacy, ownership, and troubleshooting
   guidance without chart-managed credentials, providers, or model servers.
-- Runtime v0.41.0 public exception hierarchy compatibility guidance without new
+- Runtime v1.22.0 public exception hierarchy compatibility guidance without new
   chart values, templates, resources, or deployment behavior.
-- Runtime v0.41.0 service lifecycle compatibility guidance for ordered startup,
+- Runtime v1.22.0 service lifecycle compatibility guidance for ordered startup,
   reverse shutdown, partial-startup rollback, bounded cleanup, cancellation,
   and safe failure reporting without chart-owned services, hooks, values, or
   resources.
-- Runtime v0.41.0 service registry compatibility guidance for explicit ordered
+- Runtime v1.22.0 service registry compatibility guidance for explicit ordered
   registration, stable lookup, immutable discovery, duplicate protection, and
   sealed lifecycle ownership without chart-owned registry declarations,
   plugins, health aggregation, values, templates, or resources.
-- Runtime v0.41.0 component health compatibility guidance and live endpoint
+- Runtime v1.22.0 component health compatibility guidance and live endpoint
   validation for bounded statuses, concurrent deadlines, deterministic
   aggregation, transition events, and informational HTTP behavior without new
   chart values, probes, templates, resources, or recovery policy.
-- Runtime v0.41.0 core capability registry compatibility guidance for canonical
+- Runtime v1.22.0 core capability registry compatibility guidance for canonical
   identities, explicit ordered registration, stable lookup, immutable
   discovery, duplicate protection, safe errors, sealing, and application-owned
   execution composition without chart-owned capability declarations,
   discovery endpoints, plugins, values, templates, probes, or resources.
-- Runtime v0.41.0 bounded immutable capability metadata and ordered external
+- Runtime v1.22.0 bounded immutable capability metadata and ordered external
   discovery guidance, with live provider-free `GET /v1/capabilities` validation
   and no chart-owned configuration, declarations, templates, resources, probes,
   permissions, provider details, model details, or availability policy.
-- Runtime v0.41.0 sealed-registry capability execution pipeline compatibility
+- Runtime v1.22.0 sealed-registry capability execution pipeline compatibility
   guidance and live in-pod invocation without chart-owned middleware, routing,
   values, templates, resources, probes, permissions, or execution policy.
-- Runtime v0.41.0 ordered capability middleware compatibility guidance and live
+- Runtime v1.22.0 ordered capability middleware compatibility guidance and live
   in-pod invocation without chart-owned middleware configuration, declarations,
   routing, values, templates, resources, probes, permissions, or execution
   policy.
-- Runtime v0.41.0 optional capability lifecycle compatibility guidance and live
+- Runtime v1.22.0 optional capability lifecycle compatibility guidance and live
   in-pod startup and shutdown validation without chart-owned lifecycle values,
   declarations, templates, resources, probes, permissions, CRDs, or operator
   behavior.
-- Runtime v0.41.0 capability availability compatibility guidance, positive
+- Runtime v1.22.0 capability availability compatibility guidance, positive
   schema-validated per-check deadline, ConfigMap rendering, public contract
   import, and live provider-free endpoint validation.
 - Explicit separation of informational capability availability from execution,


### PR DESCRIPTION
Closes #86

## Summary

Refresh chart release and roadmap documentation to the current runtime and chart baselines.

## Changes

- Replace stale runtime v0.41.0 references with v1.22.0.
- Add chart 1.2.x and 1.3.x compatibility rows.
- Update the roadmap date.

## Validation

- `git diff --check`
