### PR TITLE
docs: fix generated license links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 [![CI](https://github.com/trussiumhq/trussium-helm/actions/workflows/ci.yml/badge.svg)](https://github.com/trussiumhq/trussium-helm/actions/workflows/ci.yml)
-[![License](https://img.shields.io/github/license/trussiumhq/trussium-helm)](LICENSE)
+[![License](https://img.shields.io/github/license/trussiumhq/trussium-helm)](https://github.com/trussiumhq/trussium-helm/blob/main/LICENSE)
 
 The official, independently versioned Helm chart for deploying the
 [Trussium](https://github.com/trussiumhq/trussium) AI runtime to Kubernetes.
@@ -500,4 +500,4 @@ and the [roadmap](docs/ROADMAP.md).
 
 ## License
 
-Apache License 2.0. See [LICENSE](LICENSE).
+Apache License 2.0. See the [LICENSE](https://github.com/trussiumhq/trussium-helm/blob/main/LICENSE).


### PR DESCRIPTION
Closes #88

## Summary

Fix relative license links that generated a broken `/helm/LICENSE` docs-site path.

## Validation

- Link crawl reproduced and identified the broken path.
- `git diff --check`
